### PR TITLE
Feature(#23): 피드백 팝업 구현

### DIFF
--- a/views/css/index.css
+++ b/views/css/index.css
@@ -120,16 +120,16 @@ main {
   flex-grow: 1;
 }
 
-#btn-container {
-  width: 70%;
+.btn-container {
+  width: 100%;
   height: 3rem;
 
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   gap: 1rem;
 }
 
-#btn-container button {
+.btn-container button {
   width: 50%;
   border-radius: 0.5rem;
   background-color: var(--primary-color);
@@ -142,6 +142,85 @@ main {
   letter-spacing: 0.08rem;
 }
 
-#btn-container button:hover {
+.btn-container button:hover {
   opacity: 1;
+}
+
+#feedback-popup {
+  display: none;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1000;
+
+  width: 25rem;
+  padding: 2rem;
+  border-radius: 1rem;
+  background-color: white;
+  box-shadow: 0 0 1.5rem rgba(0, 0, 0, 0.1);
+}
+
+#feedback-popup section {
+  margin-bottom: 1.5rem;
+}
+
+#feedback-popup h2 {
+  margin-bottom: 1.5rem;
+}
+
+#feedback-popup h3 {
+  margin: 1rem 0;
+}
+
+#feedback-popup .radio-btn-group input[type='radio'] {
+  display: none;
+}
+
+#feedback-popup .radio-btn-group {
+  display: flex;
+}
+
+#feedback-popup .radio-btn-group label {
+  display: block;
+  cursor: pointer;
+
+  padding: 1rem;
+  margin-bottom: 1rem;
+
+  background-color: var(--secondary-color);
+  color: var(--primary-color);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+#feedback-popup .radio-btn-group label.active {
+  background-color: var(--primary-color);
+  color: var(--secondary-color);
+}
+
+#feedback-popup .radio-btn-group label:hover {
+  background-color: var(--primary-color);
+  color: var(--secondary-color);
+}
+
+#feedback-popup .radio-btn-group label:first-child {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+#feedback-popup .radio-btn-group label:last-child {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+#overlay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
 }

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -38,12 +38,50 @@
         <div id='feedback-content'>
           feedback content
         </div>
-        <div id='btn-container'>
+        <div class='btn-container'>
           <button id='save-btn'>Save</button>
           <button id='feedback-btn'>Feedback</button>
         </div>
       </section>
     </main>
+    <div id='overlay'></div>
+    <div id='feedback-popup'>
+      <h2>맞춤 피드백을 받아보세요!</h2>
+      <section>
+        <h3>어조</h3>
+        <div class='radio-btn-group'>
+          <label>
+            <input type='radio' name='tone' value='formal' checked />
+            공식적
+          </label>
+          <label>
+            <input type='radio' name='tone' value='informal' />
+            비공식적
+          </label>
+        </div>
+      </section>
+      <section>
+        <h3>목적</h3>
+        <div class='radio-btn-group'>
+          <label>
+            <input type='radio' name='purpose' value='resume' checked />
+            자소서
+          </label>
+          <label>
+            <input type='radio' name='purpose' value='email' />
+            이메일
+          </label>
+          <label>
+            <input type='radio' name='purpose' value='blog' />
+            블로그
+          </label>
+        </div>
+      </section>
+      <div class='btn-container'>
+        <button id='feedback-submit-btn'>Feedback</button>
+        <button id='feedback-cancel-btn'>Cancel</button>
+      </div>
+    </div>
   </body>
-
+  <script type='module' src='/javascript/index.js'></script>
 </html>

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -78,7 +78,7 @@
         </div>
       </section>
       <div class='btn-container'>
-        <button id='feedback-submit-btn'>Feedback</button>
+        <button id='feedback-submit-btn'>Submit</button>
         <button id='feedback-cancel-btn'>Cancel</button>
       </div>
     </div>

--- a/views/javascript/components/feedbackPopup.js
+++ b/views/javascript/components/feedbackPopup.js
@@ -1,0 +1,89 @@
+export class FeedbackPopup {
+  #holder;
+  #overlay;
+  #radioButtons;
+
+  constructor(holder, overlay) {
+    this.#holder = holder;
+    this.#overlay = overlay;
+    this.#init();
+  }
+
+  show() {
+    this.#holder.style.display = 'block';
+    this.#overlay.style.display = 'block';
+  }
+
+  #hide() {
+    this.#holder.style.display = 'none';
+    this.#overlay.style.display = 'none';
+  }
+
+  #init() {
+    this.#radioButtons = this.#holder.querySelectorAll(
+      '.radio-btn-group input[type="radio"]',
+    );
+
+    this.#radioButtons.forEach((btn) => {
+      if (btn.checked) {
+        this.#selectRadioBtn(btn);
+      }
+    });
+
+    this.handleChangeEvent = this.handleChangeEvent.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleCancel = this.handleCancel.bind(this);
+
+    this.#radioButtons.forEach((btn) =>
+      btn.addEventListener('change', () => this.handleChangeEvent(btn)),
+    );
+
+    const buttons = this.#holder.querySelectorAll('button');
+    buttons.forEach((btn) => {
+      if (btn.id === 'feedback-submit-btn') {
+        btn.addEventListener('click', this.handleSubmit);
+      } else {
+        btn.addEventListener('click', this.handleCancel);
+      }
+    });
+  }
+
+  handleChangeEvent(btn) {
+    const radioBtnGroup = this.#findRadioBtnGroup(btn);
+    const labels = radioBtnGroup.querySelectorAll('label');
+    labels.forEach((label) => this.#cancelRadioBtn(label));
+
+    if (btn.checked) {
+      this.#selectRadioBtn(btn);
+    }
+  }
+
+  handleSubmit() {
+    const selectedValues = {};
+    this.#radioButtons.forEach((btn) => {
+      if (btn.checked) {
+        const name = btn.name;
+        const value = btn.value;
+        selectedValues[name] = value;
+      }
+    });
+    // TODO 추후 CLOVA 요청으로 변경
+    alert(JSON.stringify(selectedValues));
+  }
+
+  handleCancel() {
+    this.#hide();
+  }
+
+  #findRadioBtnGroup(btn) {
+    return btn.parentElement.parentElement;
+  }
+
+  #selectRadioBtn(btn) {
+    btn.parentElement.classList.add('active');
+  }
+
+  #cancelRadioBtn(label) {
+    label.classList.remove('active');
+  }
+}

--- a/views/javascript/components/textarea.js
+++ b/views/javascript/components/textarea.js
@@ -27,6 +27,10 @@ export class Textarea {
   }
 
   static isIMECharacter(char) {
+    if (!char) {
+      return false;
+    }
+
     const code = char.charCodeAt(0);
     return (
       (code >= 0xac00 && code <= 0xd7a3) ||
@@ -88,13 +92,8 @@ export class Textarea {
       return;
     }
 
-    if (
-      key === 'Enter' ||
-      key === '.' ||
-      key === '?' ||
-      key === '!'
-    ) {
-      spellCheck(event.key);
+    if (key === 'Enter' || key === '.' || key === '?' || key === '!') {
+      spellCheck(key);
     }
   }
 

--- a/views/javascript/index.js
+++ b/views/javascript/index.js
@@ -1,0 +1,12 @@
+import { FeedbackPopup } from './components/feedbackPopup.js';
+
+const feedbackBtn = document.getElementById('feedback-btn');
+
+const feedbackPopup = new FeedbackPopup(
+  document.getElementById('feedback-popup'),
+  document.getElementById('overlay'),
+);
+
+feedbackBtn.addEventListener('click', () => {
+  feedbackPopup.show();
+});


### PR DESCRIPTION
resolved #23

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
피드백 팝업을 만든다

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 편집기 화면의 `Feedback` 버튼을 클릭하면 피드백 팝업이 화면의 정중앙에 띄워진다.
- 피드백 팝업이 띄워지면 overlay에 의해 편집기를 조작할 수 없다.
- `Submit` 버튼을 클릭하면 라디오 버튼의 key-value를 alert한다.
- `Cancel` 버튼을 클릭하면 팝업과 오버레이가 사라진다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
피드백 팝업을 닫으면서 값을 초기화하지 않았기 때문에 `비공식적`, `이메일` 선택 후 팝업을 닫으면 그 값이 유지됩니다.


## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->

![image](https://github.com/user-attachments/assets/250136f8-a59a-40ef-a425-f4a8a3186de4)
