### PR TITLE
Fix(#28): 긴문장, 맞춤법 겹치는 오류 해결 

### DIFF
--- a/views/css/spell.css
+++ b/views/css/spell.css
@@ -2,8 +2,6 @@
   position: relative;
   display: inline-block;
   background-color: rgba(255, 0, 0, 0.3); /* 투명도 조절 가능 */
-  padding: 2px;
-  border-radius: 2px;
 }
 
 /* 팝업 창 스타일 */

--- a/views/javascript/components/textarea.js
+++ b/views/javascript/components/textarea.js
@@ -55,6 +55,10 @@ export class Textarea {
     const cursorPointer = this.#getCursorPointer();
     const autoPointer = this.#autoCompleteSettings.getPointer();
 
+    if (key === 'Enter' || key === '.' || key === '?' || key === '!') {
+      spellCheck(key);
+    }
+
     if (!Textarea.isAutoCompletePosition(cursorPointer, autoPointer)) {
       this.#autoCompleteSettings.emptyCursorBox();
     }
@@ -93,9 +97,6 @@ export class Textarea {
       return;
     }
 
-    if (key === 'Enter' || key === '.' || key === '?' || key === '!') {
-      spellCheck(key);
-    }
   }
 
   handleCompositionstartEvent() {

--- a/views/javascript/spell/popup.js
+++ b/views/javascript/spell/popup.js
@@ -4,8 +4,9 @@
  * @param suggestions 제안
  * @param info 정보
  */
-function showSuggestions(element, suggestions, info) {
-  // 팝업 요소 생성
+function showSuggestions(event, element, suggestions, info) {
+  event.stopPropagation(); // 이벤트 전파 막기
+
   const popup = document.createElement('div');
   popup.className = 'popup';
   popup.innerHTML = `
@@ -15,21 +16,21 @@ function showSuggestions(element, suggestions, info) {
     <div class="close-btn">닫기</div>
   `;
 
-  // 팝업 닫기 버튼 클릭 이벤트 추가
   popup.querySelector('.close-btn').addEventListener('click', function () {
     document.body.removeChild(popup);
   });
 
-  // 팝업 반영하기 버튼 클릭 이벤트 추가
   popup.querySelector('.apply-btn').addEventListener('click', function () {
     element.outerHTML = suggestions;
     document.body.removeChild(popup);
-    // output의 텍스트를 textarea에 반영
+
     const output = document.getElementById('output');
     const textarea = document.getElementById('textarea');
-    textarea.value = output.innerText; // innerText를 사용하여 텍스트만 가져옵니다.
+    textarea.value = output.innerText;
   });
 
-  // 팝업을 문서에 추가
   document.body.appendChild(popup);
+  popup.addEventListener('click', function (e) {
+    e.stopPropagation();
+  });
 }

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -25,50 +25,53 @@ async function fetchServer(sentence) {
  * @param errors
  * @param inputText
  */
-async function displayResults(errors, inputText) {
-  let content = inputText; // 고친 결과를 저장할 변수
+function displayResults(errors, inputText) {
+  let content = inputText;
   let index = 0;
-  // 각 오류에 대해 처리
+  const output = document.getElementById('output');
+  output.innerHTML = ''; // 기존 내용 초기화
+
   errors.forEach((error) => {
     const token = error.token;
     const context = error.context;
-    const suggestions = error.suggestions.join(', '); // 배열 하나로 합치기
-    const info = error.info.replace(/\n/g, ' ').replace(/'/g, '`'); // 공백 제거 및 ' 제거
+    const suggestions = error.suggestions.join(', ');
+    const info = error.info.replace(/\n/g, ' ').replace(/'/g, '`');
 
     index = content.indexOf(context, index);
     if (index !== -1) {
       const tokenIndex = content.indexOf(token, index);
       if (tokenIndex !== -1 && tokenIndex < index + context.length) {
-        // token을 하이라이트로 감싸기
-        hightlight = `<span class="highlight-overlay" onclick="showSuggestions(this, '${suggestions}', '${info}')">${token}</span>`;
         content =
           content.substring(0, tokenIndex) +
-          hightlight +
+          `<span class="highlight-overlay" data-suggestions="${suggestions}" data-info="${info}">${token}</span>` +
           content.substring(tokenIndex + token.length);
 
-        // 다음 인덱스부터 검사 시작
-        index += hightlight.length;
-      } else {
-        // 다음 context 검색
-        index += context.length;
+        index += `<span class="highlight-overlay">${token}</span>`.length;
       }
     }
   });
 
-  // 결과를 div에 추가 <br>로 줄바꿈 유지하기
-  const resultDiv = document.getElementById('output');
-  resultDiv.innerHTML = content.replace(/\n/g, '<br>');
+  // 줄바꿈 유지하여 결과를 div에 추가
+  output.innerHTML = content.replace(/\n/g, '<br>');
+
+  // 모든 highlight-overlay 요소에 이벤트 리스너 추가
+  document.querySelectorAll('.highlight-overlay').forEach((element) => {
+    element.addEventListener('click', function(event) {
+      showSuggestions(event, element, element.getAttribute('data-suggestions'), element.getAttribute('data-info'));
+    });
+  });
 }
 
 /**
  * 맞춤법 검사 실행 부분
  */
 async function spellCheck(key) {
-  const inputText = document.getElementById('textarea').value;
-  const result = await fetchServer(inputText);
+  checkLength();
+  const inputText = document.getElementById('output').innerHTML;
+  const result = await fetchServer(inputText.replace(/<\/?span[^>]*>/gi, ''));
   if (key === 'Enter') {
     key = '\n';
   }
-  await displayResults(result, inputText + key);
-  checkLength();
+  displayResults(result, inputText + key);
+  setEvent();
 }


### PR DESCRIPTION
1. 엔터가 안먹는 것 때문에 위로 맞춤법 검사 올리기
2. 이벤트 다는 로직을 onclick에서 리스너로 변경
3. 이벤트 전파 막기
4. 긴문장 후 맞춤법 후 이벤트 다시 달기

<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
긴문장, 맞춤법 겹치는 오류 해결
resolved #28 

## 작업 사항
1. 엔터가 안먹는 것 때문에 위로 맞춤법 검사 올리기
2. 이벤트 다는 로직을 onclick에서 리스너로 변경
3. 이벤트 전파 막기
4. 긴문장 후 맞춤법 후 이벤트 다시 달기

## 고민한 점들(필수 X)
긴문장 → 모든 문장을 감싸고, 그 이후에 addEventListener으로 요청하는 거 추가   
맞춤법 → 감싸면서 해당 제안과 정보를 같이 onclick으로 달아주기   
그래서 제가 addEventListener형식으로 바꿔봤습니다.   


