### PR TITLE
Fix(#32): 맞춤법 오류 처리 및 팝업 반영

### DIFF
--- a/src/spell/spell.service.ts
+++ b/src/spell/spell.service.ts
@@ -18,7 +18,7 @@ export class SpellService {
       return results;
     } catch (error) {
       console.error('Error during spell check:', error); // TODO: 로그 출력으로 변경하기
-      throw error;
+      return [];
     }
   }
 

--- a/views/css/spell.css
+++ b/views/css/spell.css
@@ -6,30 +6,68 @@
 
 /* 팝업 창 스타일 */
 .popup {
-  position: fixed;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  width: 500px;
   padding: 20px;
-  background-color: white;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  background-color: #f9f9f9;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  font-family: Arial, sans-serif;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   z-index: 1000;
 }
-
-.apply-btn {
-  display: block;
-  margin-top: 10px;
-  text-align: center;
-  cursor: pointer;
-  color: green;
-  text-decoration: underline;
+.popup .text-container {
+  font-size: 24px;
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
 }
-
-.close-btn {
-  display: block;
+.popup .original {
+  color: rgba(0, 0, 0, 0.5);
+  text-decoration: line-through;
+  margin-right: 10px;
+}
+.popup .arrow {
+  margin-right: 10px;
+}
+.popup .suggestion {
+  color: #007bff;
+}
+.popup .info-container {
+  border: 1px solid #ccc;
+  padding: 10px;
   margin-top: 10px;
+  margin-bottom: 20px;
+  background-color: #f1f1f1;
+}
+.popup .info-title {
+  margin-bottom: 10px;
+  font-weight: bold;
+}
+.popup .info-content {
+  margin-bottom: 0;
+  white-space: pre-wrap;
+
+}
+.popup .btn-container {
+  display: flex;
+  justify-content: space-between;
+}
+.popup .btn {
+  padding: 10px 20px;
+  background-color: #007bff;
+  color: #fff;
   text-align: center;
+  border-radius: 5px;
   cursor: pointer;
-  color: blue;
-  text-decoration: underline;
+  text-decoration: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.popup .btn.close-btn {
+  background-color: #6c757d;
 }

--- a/views/css/spell.css
+++ b/views/css/spell.css
@@ -4,68 +4,30 @@
 
 /* 팝업 창 스타일 */
 .popup {
-  width: 500px;
-  padding: 20px;
-  background-color: #f9f9f9;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-  font-family: Arial, sans-serif;
   position: fixed;
-  top: 50%;
   left: 50%;
+  top: 50%;
   transform: translate(-50%, -50%);
+  padding: 20px;
+  background-color: white;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   z-index: 1000;
 }
-.popup .text-container {
-  font-size: 24px;
-  margin-bottom: 10px;
-  display: flex;
-  align-items: center;
-}
-.popup .original {
-  color: rgba(0, 0, 0, 0.5);
-  text-decoration: line-through;
-  margin-right: 10px;
-}
-.popup .arrow {
-  margin-right: 10px;
-}
-.popup .suggestion {
-  color: #007bff;
-}
-.popup .info-container {
-  border: 1px solid #ccc;
-  padding: 10px;
-  margin-top: 10px;
-  margin-bottom: 20px;
-  background-color: #f1f1f1;
-}
-.popup .info-title {
-  margin-bottom: 10px;
-  font-weight: bold;
-}
-.popup .info-content {
-  margin-bottom: 0;
-  white-space: pre-wrap;
 
-}
-.popup .btn-container {
-  display: flex;
-  justify-content: space-between;
-}
-.popup .btn {
-  padding: 10px 20px;
-  background-color: #007bff;
-  color: #fff;
+.apply-btn {
+  display: block;
+  margin-top: 10px;
   text-align: center;
-  border-radius: 5px;
   cursor: pointer;
-  text-decoration: none;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  color: green;
+  text-decoration: underline;
 }
-.popup .btn.close-btn {
-  background-color: #6c757d;
+
+.close-btn {
+  display: block;
+  margin-top: 10px;
+  text-align: center;
+  cursor: pointer;
+  color: blue;
+  text-decoration: underline;
 }

--- a/views/javascript/components/textarea.js
+++ b/views/javascript/components/textarea.js
@@ -58,7 +58,7 @@ export class Textarea {
     const autoPointer = this.#autoCompleteSettings.getPointer();
 
     if (key === 'Enter' || key === '.' || key === '?' || key === '!') {
-      spellCheck(key);
+      spellCheck();
     }
 
     if (!Textarea.isAutoCompletePosition(cursorPointer, autoPointer)) {

--- a/views/javascript/components/textarea.js
+++ b/views/javascript/components/textarea.js
@@ -1,3 +1,5 @@
+import {spellCheck} from '../spell/spellCheck.js'
+
 export class Textarea {
   #holder;
   #autoCompleteSettings;

--- a/views/javascript/spell/popup.js
+++ b/views/javascript/spell/popup.js
@@ -1,45 +1,29 @@
-﻿/**
+﻿import { OutputPopup } from "../components/outputPopup.js";
+/**
  * 색칠된 것 클릭 이벤트 추가
  * @param element 어떤 div인지
  * @param suggestions 제안
  * @param info 정보
  */
-function showSuggestions(event, element, suggestions, info) {
+export function showSuggestions(event, element, suggestions, info) {
   event.stopPropagation(); // 이벤트 전파 막기
 
-  const popup = document.createElement('div');
-  popup.className = 'popup';
-  popup.innerHTML = `
-    <div class="text-container">
-      <span class="original">${element.innerText}</span>
-      <span class="arrow">➡️</span>
-      <span class="suggestion">${suggestions}</span>
-    </div>
-    <div class="info-container">
-      <div class="info-title">정보:</div>
-      <div class="info-content">${info.replace(/\.\s*/g, '.\n')}</div>
-    </div>
-    <div class="btn-container">
-      <div class="btn apply-btn">반영하기</div>
-      <div class="btn close-btn">닫기</div>
-    </div>
-  `;
+  const outputPopup = new OutputPopup(
+    `${element.innerText} ➡️ ${suggestions}`,
+    `
+      <div class="info-container">
+        <div class="info-title">정보:</div>
+        <div class="info-content">${info.replace(/\.\s*/g, '.\n')}</div>
+      </div>
+    `,
+    () => {
+      element.outerHTML = suggestions;
+      const output = document.getElementById('output');
+      const textarea = document.getElementById('textarea');
+      textarea.value = output.innerText;
+      outputPopup.hide();
+    },
+  );
 
-  popup.querySelector('.close-btn').addEventListener('click', function () {
-    document.body.removeChild(popup);
-  });
-
-  popup.querySelector('.apply-btn').addEventListener('click', function () {
-    element.outerHTML = suggestions;
-    document.body.removeChild(popup);
-
-    const output = document.getElementById('output');
-    const textarea = document.getElementById('textarea');
-    textarea.value = output.innerText;
-  });
-
-  document.body.appendChild(popup);
-  popup.addEventListener('click', function (e) {
-    e.stopPropagation();
-  });
+  outputPopup.show();
 }

--- a/views/javascript/spell/popup.js
+++ b/views/javascript/spell/popup.js
@@ -10,10 +10,19 @@ function showSuggestions(event, element, suggestions, info) {
   const popup = document.createElement('div');
   popup.className = 'popup';
   popup.innerHTML = `
-    <div>Suggestions: ${suggestions}</div>
-    <div>Info: ${info}</div>
-    <div class="apply-btn">반영하기</div>
-    <div class="close-btn">닫기</div>
+    <div class="text-container">
+      <span class="original">${element.innerText}</span>
+      <span class="arrow">➡️</span>
+      <span class="suggestion">${suggestions}</span>
+    </div>
+    <div class="info-container">
+      <div class="info-title">정보:</div>
+      <div class="info-content">${info.replace(/\.\s*/g, '.\n')}</div>
+    </div>
+    <div class="btn-container">
+      <div class="btn apply-btn">반영하기</div>
+      <div class="btn close-btn">닫기</div>
+    </div>
   `;
 
   popup.querySelector('.close-btn').addEventListener('click', function () {

--- a/views/javascript/spell/popup.js
+++ b/views/javascript/spell/popup.js
@@ -22,6 +22,7 @@ export function showSuggestions(event, element, suggestions, info) {
       const textarea = document.getElementById('textarea');
       textarea.value = output.innerText;
       outputPopup.hide();
+      textarea.focus(); // 커서를 textarea로 이동
     },
   );
 

--- a/views/javascript/spell/popup.js
+++ b/views/javascript/spell/popup.js
@@ -5,11 +5,11 @@
  * @param suggestions 제안
  * @param info 정보
  */
-export function showSuggestions(event, element, suggestions, info) {
+export function showSuggestion(event, element, suggestion, info) {
   event.stopPropagation(); // 이벤트 전파 막기
 
   const outputPopup = new OutputPopup(
-    `${element.innerText} ➡️ ${suggestions}`,
+    `${element.innerText} ➡️ ${suggestion}`,
     `
       <div class="info-container">
         <div class="info-title">정보:</div>
@@ -17,7 +17,7 @@ export function showSuggestions(event, element, suggestions, info) {
       </div>
     `,
     () => {
-      element.outerHTML = suggestions;
+      element.outerHTML = suggestion;
       const output = document.getElementById('output');
       const textarea = document.getElementById('textarea');
       textarea.value = output.innerText;

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -67,7 +67,7 @@ function setHighlightEvent(errors, inputText) {
  */
 function setEvent(){
   document.querySelectorAll('.highlight.red').forEach((element) => {
-    element.addEventListener('click', function (event) {
+    element.addEventListener('click', (event) => {
       showSuggestion(
         event,
         element,
@@ -82,7 +82,7 @@ let debounceTimer;
 
 // 디바운싱 함수
 function debounce(fn, delay) {
-  return function(...args) {
+  return (...args) => {
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
       fn(...args);

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -24,9 +24,18 @@ async function fetchServer(sentence) {
  * resultDiv에 색칠하고 나타내기
  * @param errors
  * @param inputText
+ * @param key
  */
-function displayResults(errors, inputText) {
-  let content = inputText;
+function displayResults(errors, inputText, key) {
+  if (!errors) {
+    return ;
+  }
+
+  if (key === 'Enter') {
+    key = '\n';
+  }
+
+  let content = inputText + key;
   let index = 0;
   const output = document.getElementById('output');
   output.innerHTML = ''; // 기존 내용 초기화
@@ -69,9 +78,6 @@ async function spellCheck(key) {
   checkLength();
   const inputText = document.getElementById('output').innerHTML;
   const result = await fetchServer(inputText.replace(/<\/?span[^>]*>/gi, ''));
-  if (key === 'Enter') {
-    key = '\n';
-  }
-  displayResults(result, inputText + key);
+  displayResults(result, inputText, key);
   setEvent();
 }

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -1,4 +1,5 @@
-﻿/**
+﻿import { showSuggestions } from './popup.js'
+/**
  * node 서버로 맞춤법 요청
  * @param sentence
  * @returns {Promise<any>}
@@ -79,7 +80,7 @@ function displayResults(errors, inputText, key) {
 /**
  * 맞춤법 검사 실행 부분
  */
-async function spellCheck(key) {
+export async function spellCheck(key) {
   checkLength();
   const inputText = document.getElementById('output').innerHTML;
   const result = await fetchServer(inputText.replace(/<\/?span[^>]*>/gi, ''));

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -25,18 +25,13 @@ async function fetchServer(sentence) {
  * resultDiv에 색칠하고 나타내기
  * @param errors
  * @param inputText
- * @param key
  */
-function displayResults(errors, inputText, key) {
+function displayResults(errors, inputText) {
   if (!errors) {
     return ;
   }
 
-  if (key === 'Enter') {
-    key = '\n';
-  }
-
-  let content = inputText + key;
+  let content = inputText;
   let index = 0;
   const output = document.getElementById('output');
   output.innerHTML = ''; // 기존 내용 초기화
@@ -77,13 +72,26 @@ function displayResults(errors, inputText, key) {
   });
 }
 
+let debounceTimer;
+
+// 디바운싱 함수
+function debounce(fn, delay) {
+  return function(...args) {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      fn(...args);
+    }, delay);
+  };
+}
+
 /**
- * 맞춤법 검사 실행 부분
+ * 맞춤법 검사 실행 부분 디바운싱 도입
  */
-export async function spellCheck(key) {
+export const spellCheck = debounce(async () => {
   checkLength();
   const inputText = document.getElementById('output').innerHTML;
   const result = await fetchServer(inputText.replace(/<\/?span[^>]*>/gi, ''));
-  displayResults(result, inputText, key);
+  displayResults(result, inputText);
   setEvent();
 }
+, 200);

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -58,8 +58,12 @@ function displayResults(errors, inputText) {
 
   // 줄바꿈 유지하여 결과를 div에 추가
   output.innerHTML = content.replace(/\n/g, '<br>');
+  setEvent();
+  
+}
 
-  // 모든 highlight.red 요소에 이벤트 리스너 추가
+// 모든 highlight.red 요소에 이벤트 리스너 추가
+function setEvent(){
   document.querySelectorAll('.highlight.red').forEach((element) => {
     element.addEventListener('click', function (event) {
       showSuggestions(
@@ -93,5 +97,4 @@ export const spellCheck = debounce(async () => {
   const result = await fetchServer(inputText.replace(/<\/?span[^>]*>/gi, ''));
   displayResults(result, inputText);
   setEvent();
-}
-, 200);
+}, 200);

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -1,4 +1,4 @@
-﻿import { showSuggestions } from './popup.js'
+﻿import { showSuggestion } from './popup.js'
 /**
  * node 서버로 맞춤법 요청
  * @param sentence
@@ -22,11 +22,11 @@ async function fetchServer(sentence) {
 }
 
 /**
- * resultDiv에 색칠하고 나타내기
+ * output에 색칠하고 나타내기
  * @param errors
  * @param inputText
  */
-function displayResults(errors, inputText) {
+function setHighlightEvent(errors, inputText) {
   if (!errors) {
     return ;
   }
@@ -62,11 +62,13 @@ function displayResults(errors, inputText) {
   
 }
 
-// 모든 highlight.red 요소에 이벤트 리스너 추가
+/**
+ * 모든 highlight.red 요소에 이벤트 리스너 추가
+ */
 function setEvent(){
   document.querySelectorAll('.highlight.red').forEach((element) => {
     element.addEventListener('click', function (event) {
-      showSuggestions(
+      showSuggestion(
         event,
         element,
         element.getAttribute('data-suggestions'),
@@ -95,6 +97,6 @@ export const spellCheck = debounce(async () => {
   checkLength();
   const inputText = document.getElementById('output').innerHTML;
   const result = await fetchServer(inputText.replace(/<\/?span[^>]*>/gi, ''));
-  displayResults(result, inputText);
+  setHighlightEvent(result, inputText);
   setEvent();
 }, 200);

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -20,8 +20,8 @@
     {{> nav }}
     {{{body}}}
     <script type="module" src="/javascript/index.js"></script>
-    <script src="/javascript/spell/spellCheck.js"></script>
-    <script src="/javascript/spell/popup.js"></script>
+    <script type="module" src="/javascript/spell/spellCheck.js"></script>
+    <script type="module" src="/javascript/spell/popup.js"></script>
     <script src="/javascript/longSentence/longSentence.js"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
맞춤법 오류 처리 및 팝업 반영 
resolved #32 

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
1. 한스펠 오류를 처리하기 위해 빈배열 반환, 디바운싱 도입
2. 팝업 공통된 부분으로 합치기

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
![image](https://github.com/user-attachments/assets/88f2b82e-8c57-4d0c-83b2-4fe789c8baaa)

디바운싱과 쓰로틀링 중 지금은 입력을 계속하면 맞춤법이 사라지니까
디바운싱으로 마지막 요청만 들어가게 처리했습니다.


## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
