### PR TITLE
Feature(#8): 긴 문장 감지

### DIFF
--- a/src/clova/clova.controller.ts
+++ b/src/clova/clova.controller.ts
@@ -1,11 +1,14 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { ClovaService } from './clova.service';
+import { ParsedSentenceService } from './parsedSentence.service';
 import { SynonymService } from './synonym.service';
 
 @Controller('clova')
 export class ClovaController {
-  constructor(private readonly clovaService: ClovaService,
-    private readonly synonymService: SynonymService
+  constructor(
+    private readonly clovaService: ClovaService,
+    private readonly synonymService: SynonymService,
+    private readonly parsedSentenceService: ParsedSentenceService,
   ) {}
 
   @Post('/synonym')
@@ -13,4 +16,8 @@ export class ClovaController {
     return this.synonymService.getSynonyms(text);
   }
 
+  @Post('/parsed-line')
+  parsedLine(@Body('text') text: string) {
+    return this.parsedSentenceService.getParsedSentence(text);
+  }
 }

--- a/src/clova/clova.module.ts
+++ b/src/clova/clova.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { ClovaService } from './clova.service';
 import { ClovaController } from './clova.controller';
+import { ClovaService } from './clova.service';
+import { ParsedSentenceService } from './parsedSentence.service';
 import { SynonymService } from './synonym.service';
 
 @Module({
   controllers: [ClovaController],
-  providers: [ClovaService, SynonymService],
+  providers: [ClovaService, SynonymService, ParsedSentenceService],
 })
 export class ClovaModule {}

--- a/src/clova/parsedSentence.service.ts
+++ b/src/clova/parsedSentence.service.ts
@@ -18,7 +18,7 @@ export class ParsedSentenceService {
         {
           role: 'system',
           content:
-            '문장이 100자가 넘는다면, 한 문장을 100자 미만으로 나눠줘. 결과는 나뉜 문장을 줄글로 보여줘.',
+            '문장이 100자가 넘는다면, 한 문장을 100자 미만으로 나눠줘. 결과는 나뉜 문장만을 줄글로 보여줘.',
         },
         {
           role: 'user',
@@ -39,7 +39,7 @@ export class ParsedSentenceService {
       const response = await axios.post(this.apiUrl, data, {
         headers: this.headers,
       });
-      return response.data;
+      return response.data.result.message.content;
     } catch (error) {
       console.error(
         'Error:',

--- a/src/clova/parsedSentence.service.ts
+++ b/src/clova/parsedSentence.service.ts
@@ -1,0 +1,51 @@
+import axios from 'axios';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ParsedSentenceService {
+  private readonly apiUrl = process.env.LONG_SENTENCE_API_URL;
+  private readonly headers = {
+    'X-NCP-CLOVASTUDIO-API-KEY': process.env.X_NCP_CLOVASTUDIO_API_KEY,
+    'X-NCP-APIGW-API-KEY': process.env.X_NCP_APIGW_API_KEY,
+    'X-NCP-CLOVASTUDIO-REQUEST-ID':
+      process.env.LONG_SENTENCE_X_NCP_CLOVASTUDIO_REQUEST_ID,
+    'Content-Type': 'application/json',
+  };
+
+  async getParsedSentence(text: string): Promise<any> {
+    const data = {
+      messages: [
+        {
+          role: 'system',
+          content:
+            '문장이 100자가 넘는다면, 한 문장을 100자 미만으로 나눠줘. 결과는 나뉜 문장을 줄글로 보여줘.',
+        },
+        {
+          role: 'user',
+          content: text,
+        },
+      ],
+      topP: 0.8,
+      topK: 0,
+      maxTokens: 256,
+      temperature: 0.8,
+      repeatPenalty: 5.0,
+      stopBefore: [],
+      includeAiFilters: true,
+      seed: 0,
+    };
+
+    try {
+      const response = await axios.post(this.apiUrl, data, {
+        headers: this.headers,
+      });
+      return response.data;
+    } catch (error) {
+      console.error(
+        'Error:',
+        error.response ? error.response.data : error.message,
+      );
+      throw new Error('Failed to fetch parsed sentence from CLOVA API');
+    }
+  }
+}

--- a/views/css/outputPopup.css
+++ b/views/css/outputPopup.css
@@ -15,3 +15,30 @@
   margin-bottom: 0;
   white-space: pre-wrap;
 }
+
+.spinner-wrap {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
+.spinner {
+  border: 8px solid rgba(0, 0, 0, 0.1); /* 외곽선 */
+  border-top: 8px solid var(--primary-color); /* 상단 부분을 강조 */
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  justify-content: center;
+  align-items: center;
+  animation: spin 1s linear infinite; /* 애니메이션 */
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/views/javascript/components/outputPopup.js
+++ b/views/javascript/components/outputPopup.js
@@ -41,4 +41,14 @@ export class OutputPopup extends Popup {
     this.#cancelBtn = this.holder.querySelector('#output-cancel-btn');
     this.#cancelBtn.onclick = () => this.hide();
   }
+
+  hideButton() {
+    this.#applyBtn.style.display = 'none';
+    this.#cancelBtn.style.display = 'none';
+  }
+
+  showButton() {
+    this.#applyBtn.style.display = 'flex';
+    this.#cancelBtn.style.display = 'flex';
+  }
 }

--- a/views/javascript/components/outputPopup.js
+++ b/views/javascript/components/outputPopup.js
@@ -12,10 +12,10 @@ export class OutputPopup extends Popup {
       document.getElementById('overlay'),
     );
     this.#init();
-    this.#set(title, content, applyCallback);
+    this.set(title, content, applyCallback);
   }
 
-  #set(title, content, applyCallback) {
+  set(title, content, applyCallback) {
     this.#setTitle(title);
     this.#setContent(content);
 

--- a/views/javascript/components/textarea.js
+++ b/views/javascript/components/textarea.js
@@ -1,4 +1,5 @@
-import {spellCheck} from '../spell/spellCheck.js'
+import { checkLength } from '../longSentence/longSentence.js';
+import { spellCheck } from '../spell/spellCheck.js';
 
 export class Textarea {
   #holder;
@@ -99,7 +100,6 @@ export class Textarea {
       this.#setNextCursorPointer(autoPointer, ending);
       return;
     }
-
   }
 
   handleCompositionstartEvent() {

--- a/views/javascript/longSentence/longSentence.js
+++ b/views/javascript/longSentence/longSentence.js
@@ -1,4 +1,6 @@
-const parseSentence = async (sentence) => {
+import { showSuggestion } from './popup.js';
+
+export const parseSentence = async (sentence) => {
   const url = 'http://localhost:3000/clova/parsed-line';
   const data = {
     text: sentence,
@@ -14,7 +16,7 @@ const parseSentence = async (sentence) => {
   return await response.text();
 };
 
-const changePage = (span, textarea, output) => {
+export const changePage = (span, textarea, output) => {
   const parsedText = span.dataset.tooltip;
   const textNode = document.createTextNode(parsedText);
   span.parentNode.replaceChild(textNode, span);
@@ -24,18 +26,13 @@ const changePage = (span, textarea, output) => {
 const setEvent = () => {
   const tag = document.querySelectorAll('.highlight.yellow');
   tag.forEach((span) => {
-    span.addEventListener('click', () => {
-      span.innerText = changePage(span, textarea, output);
-    });
-
-    span.addEventListener('mouseenter', async () => {
-      span.classList.add('tooltip');
-      span.setAttribute('data-tooltip', await parseSentence(span.innerText));
+    span.addEventListener('click', (event) => {
+      showSuggestion(event, span);
     });
   });
 };
 
-const checkLength = () => {
+export const checkLength = () => {
   const textarea = document.getElementById('textarea');
   const output = document.getElementById('output');
 
@@ -44,7 +41,7 @@ const checkLength = () => {
   let outputContent = '';
   if (sentences) {
     sentences.forEach((sentence) => {
-      if (sentence.length >= 15) {
+      if (sentence.length >= 100) {
         sentence = '<span class="highlight yellow">' + sentence + '</span>';
       }
       outputContent += sentence;

--- a/views/javascript/longSentence/longSentence.js
+++ b/views/javascript/longSentence/longSentence.js
@@ -1,6 +1,17 @@
-const parseSentence = (sentence) => {
-  // 여기서 클로바 API 호출
-  return sentence + ' 에서 바뀐 문장';
+const parseSentence = async (sentence) => {
+  const url = 'http://localhost:3000/clova/parsed-line';
+  const data = {
+    text: sentence,
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+  return await response.text();
 };
 
 const changePage = (span, textarea, output) => {
@@ -17,9 +28,9 @@ const setEvent = () => {
       span.innerText = changePage(span, textarea, output);
     });
 
-    span.addEventListener('mouseenter', () => {
+    span.addEventListener('mouseenter', async () => {
       span.classList.add('tooltip');
-      span.setAttribute('data-tooltip', parseSentence(span.innerText));
+      span.setAttribute('data-tooltip', await parseSentence(span.innerText));
     });
   });
 };

--- a/views/javascript/longSentence/popup.js
+++ b/views/javascript/longSentence/popup.js
@@ -1,0 +1,22 @@
+import { OutputPopup } from '../components/outputPopup.js';
+import { parseSentence } from './longSentence.js';
+
+export async function showSuggestion(event, span) {
+  event.stopPropagation(); // 이벤트 전파 막기
+
+  const suggestion = await parseSentence(span.innerText);
+  const outputPopup = new OutputPopup(
+    '긴 문장을 다음과 같이 수정해보세요.',
+    suggestion,
+    () => {
+      span.outerHTML = suggestion;
+      const output = document.getElementById('output');
+      const textarea = document.getElementById('textarea');
+      textarea.value = output.innerText;
+      outputPopup.hide();
+      textarea.focus(); // 커서를 textarea로 이동
+    },
+  );
+
+  outputPopup.show();
+}

--- a/views/javascript/longSentence/popup.js
+++ b/views/javascript/longSentence/popup.js
@@ -12,9 +12,9 @@ export async function showSuggestion(event, span) {
       <div class="spinner">
       </div>
     </div>`;
+  outputPopup.hideButton();
 
   const suggestion = await parseSentence(span.innerText);
-
   outputPopup.set('긴 문장을 다음과 같이 수정해보세요.', suggestion, () => {
     span.outerHTML = suggestion;
     const output = document.getElementById('output');
@@ -23,4 +23,5 @@ export async function showSuggestion(event, span) {
     outputPopup.hide();
     textarea.focus(); // 커서를 textarea로 이동
   });
+  outputPopup.showButton();
 }

--- a/views/javascript/longSentence/popup.js
+++ b/views/javascript/longSentence/popup.js
@@ -4,19 +4,23 @@ import { parseSentence } from './longSentence.js';
 export async function showSuggestion(event, span) {
   event.stopPropagation(); // 이벤트 전파 막기
 
-  const suggestion = await parseSentence(span.innerText);
-  const outputPopup = new OutputPopup(
-    '긴 문장을 다음과 같이 수정해보세요.',
-    suggestion,
-    () => {
-      span.outerHTML = suggestion;
-      const output = document.getElementById('output');
-      const textarea = document.getElementById('textarea');
-      textarea.value = output.innerText;
-      outputPopup.hide();
-      textarea.focus(); // 커서를 textarea로 이동
-    },
-  );
-
+  const outputPopup = new OutputPopup('긴 문장을 분석 중입니다...', '', null);
   outputPopup.show();
+  const outputContent = document.getElementById('output-popup-content');
+  outputContent.innerHTML = `
+    <div class="spinner-wrap">
+      <div class="spinner">
+      </div>
+    </div>`;
+
+  const suggestion = await parseSentence(span.innerText);
+
+  outputPopup.set('긴 문장을 다음과 같이 수정해보세요.', suggestion, () => {
+    span.outerHTML = suggestion;
+    const output = document.getElementById('output');
+    const textarea = document.getElementById('textarea');
+    textarea.value = output.innerText;
+    outputPopup.hide();
+    textarea.focus(); // 커서를 textarea로 이동
+  });
 }

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -22,6 +22,6 @@
     <script type="module" src="/javascript/index.js"></script>
     <script type="module" src="/javascript/spell/spellCheck.js"></script>
     <script type="module" src="/javascript/spell/popup.js"></script>
-    <script src="/javascript/longSentence/longSentence.js"></script>
+    <script type="module" src="/javascript/longSentence/longSentence.js"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
close #8 

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- CLOVA Studio API 연결해서 분리된 문장들 받아오기
- 결과 받아온 것 화면에 팝업으로 보여주기
- API 호출 시간 약 1213ms
    - 호출 대기 시간동안 로딩 중 화면 띄우기

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

- 생각보다 CLOVA Studio 파싱 결과가 좋지 못했습니다. 가끔씩 요청을 보냈는데 똑같은 문장을 뱉어내는 경우가 있어서 system 프롬프트를 추후에 수정할 예정입니다.
- 지금은 클릭해서 팝업을 띄울 때 API 요청 보내서 받아오고 반영하는 식으로 했는데, 나중에는 글 내용이 바뀌지 않았는데 다시 클릭했을 때 API 호출 없이 기존의 내용을 받아올 수 있게 수정하면 좋을 것 같습니다.

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->

- API 호출 결과 받아올 때까지 로딩 화면
<img width="477" alt="image" src="https://github.com/user-attachments/assets/434d2e30-8601-4b70-9b97-a89508895541">

- 피드백 받아온 것 보여주는 팝업 화면
<img width="477" alt="image" src="https://github.com/user-attachments/assets/cfe5853f-30b4-482b-8c99-56c9004f1217">

- `반영하기` 클릭 시 글쓰기 창에 반영
<img width="477" alt="image" src="https://github.com/user-attachments/assets/c210bd08-1f22-4093-a846-c655185b08d7">
