### PR TITLE
Fix(#42): 맞춤법 오류 수정

### DIFF
--- a/src/spell/spell.service.ts
+++ b/src/spell/spell.service.ts
@@ -6,7 +6,7 @@ export class SpellService {
   async check(sentence: string): Promise<SpellCheckResult[]> {
     try {
       // 텍스트를 1000자 이하로 나누기
-      const chunks = this.splitText(sentence.replace(/[?!.]/g, '\n'), 1000);
+      const chunks = this.splitText(sentence.replace(/<br>/g, '\n'), 1000);
       let results: SpellCheckResult[] = [];
 
       // 각 청크에 대해 맞춤법 검사

--- a/views/javascript/components/textarea.js
+++ b/views/javascript/components/textarea.js
@@ -1,9 +1,8 @@
-import { checkLength } from '../longSentence/longSentence.js';
 import {
-  setHighlightEvent,
-  spellCheck,
-  spellErrors,
-} from '../spell/spellCheck.js';
+  checkLength,
+  setLongSentenceEvent,
+} from '../longSentence/longSentence.js';
+import { setSpellHightlight, spellCheck } from '../spell/spellCheck.js';
 
 export class Textarea {
   #holder;
@@ -55,7 +54,8 @@ export class Textarea {
       event.preventDefault();
     }
     checkLength(event);
-    setHighlightEvent(spellErrors);
+    setSpellHightlight();
+    setLongSentenceEvent();
   }
 
   handleKeydownEvent(event) {

--- a/views/javascript/components/textarea.js
+++ b/views/javascript/components/textarea.js
@@ -1,5 +1,9 @@
 import { checkLength } from '../longSentence/longSentence.js';
-import { spellCheck } from '../spell/spellCheck.js';
+import {
+  setHighlightEvent,
+  spellCheck,
+  spellErrors,
+} from '../spell/spellCheck.js';
 
 export class Textarea {
   #holder;
@@ -51,6 +55,7 @@ export class Textarea {
       event.preventDefault();
     }
     checkLength(event);
+    setHighlightEvent(spellErrors);
   }
 
   handleKeydownEvent(event) {

--- a/views/javascript/longSentence/longSentence.js
+++ b/views/javascript/longSentence/longSentence.js
@@ -23,7 +23,7 @@ export const changePage = (span, textarea, output) => {
   textarea.value = output.innerText;
 };
 
-const setEvent = () => {
+export const setLongSentenceEvent = () => {
   const tag = document.querySelectorAll('.highlight.yellow');
   tag.forEach((span) => {
     span.addEventListener('click', (event) => {
@@ -41,13 +41,12 @@ export const checkLength = () => {
   let outputContent = '';
   if (sentences) {
     sentences.forEach((sentence) => {
-      if (sentence.length >= 100) {
+      if (sentence.length >= 20) {
         sentence = '<span class="highlight yellow">' + sentence + '</span>';
       }
       outputContent += sentence;
     });
 
     output.innerHTML = outputContent.replace(/\n/g, '<br>');
-    setEvent();
   }
 };

--- a/views/javascript/longSentence/popup.js
+++ b/views/javascript/longSentence/popup.js
@@ -1,6 +1,6 @@
 import { OutputPopup } from '../components/outputPopup.js';
+import { spellCheck } from '../spell/spellCheck.js';
 import { parseSentence } from './longSentence.js';
-import { spellCheck } from './spellCheck.js';
 
 export async function showSuggestion(event, span) {
   event.stopPropagation(); // 이벤트 전파 막기

--- a/views/javascript/longSentence/popup.js
+++ b/views/javascript/longSentence/popup.js
@@ -1,5 +1,6 @@
 import { OutputPopup } from '../components/outputPopup.js';
 import { parseSentence } from './longSentence.js';
+import { spellCheck } from './spellCheck.js';
 
 export async function showSuggestion(event, span) {
   event.stopPropagation(); // 이벤트 전파 막기
@@ -20,6 +21,7 @@ export async function showSuggestion(event, span) {
     const output = document.getElementById('output');
     const textarea = document.getElementById('textarea');
     textarea.value = output.innerText;
+    spellCheck(); // 반영하기 클릭 시 다시 맞춤법 검사
     outputPopup.hide();
     textarea.focus(); // 커서를 textarea로 이동
   });

--- a/views/javascript/spell/popup.js
+++ b/views/javascript/spell/popup.js
@@ -1,4 +1,5 @@
-﻿import { OutputPopup } from "../components/outputPopup.js";
+﻿import { OutputPopup } from '../components/outputPopup.js';
+
 /**
  * 색칠된 것 클릭 이벤트 추가
  * @param element 어떤 div인지

--- a/views/javascript/spell/popup.js
+++ b/views/javascript/spell/popup.js
@@ -1,4 +1,5 @@
 ﻿import { OutputPopup } from '../components/outputPopup.js';
+import { spellCheck } from './spellCheck.js';
 
 /**
  * 색칠된 것 클릭 이벤트 추가
@@ -22,6 +23,7 @@ export function showSuggestion(event, element, suggestion, info) {
       const output = document.getElementById('output');
       const textarea = document.getElementById('textarea');
       textarea.value = output.innerText;
+      spellCheck(); // 반영하기 클릭 시 다시 맞춤법 검사
       outputPopup.hide();
       textarea.focus(); // 커서를 textarea로 이동
     },

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -1,4 +1,7 @@
-﻿import { checkLength } from '../longSentence/longSentence.js';
+﻿import {
+  checkLength,
+  setLongSentenceEvent,
+} from '../longSentence/longSentence.js';
 import { showSuggestion } from './popup.js';
 
 /**
@@ -27,8 +30,8 @@ async function fetchServer(sentence) {
  * output에 색칠하고 나타내기
  * @param errors
  */
-export function setHighlightEvent(errors) {
-  if (errors.length === 0) {
+export function setSpellHightlight() {
+  if (spellErrors.length === 0) {
     return;
   }
 
@@ -36,8 +39,8 @@ export function setHighlightEvent(errors) {
   const output = document.getElementById('output');
   let content = output.innerHTML;
   output.innerHTML = ''; // 기존 내용 초기화
-  console.log(errors);
-  errors.forEach((error) => {
+
+  spellErrors.forEach((error) => {
     const token = error.token;
     const suggestions = error.suggestions.join(', ');
     const info = error.info.replace(/\n/g, ' ').replace(/'/g, '`');
@@ -56,13 +59,13 @@ export function setHighlightEvent(errors) {
 
   // 줄바꿈 유지하여 결과를 div에 추가
   output.innerHTML = content.replace(/\n/g, '<br>');
-  setEvent();
+  setSpellEvent();
 }
 
 /**
  * 모든 highlight.red 요소에 이벤트 리스너 추가
  */
-function setEvent() {
+function setSpellEvent() {
   document.querySelectorAll('.highlight.red').forEach((element) => {
     element.addEventListener('click', (event) => {
       showSuggestion(
@@ -95,6 +98,6 @@ export const spellCheck = debounce(async () => {
   checkLength();
   const inputText = document.getElementById('output').innerHTML;
   spellErrors = await fetchServer(inputText.replace(/<\/?span[^>]*>/gi, ''));
-  setHighlightEvent(spellErrors);
-  setEvent();
+  setSpellHightlight();
+  setLongSentenceEvent();
 }, 100);

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -28,7 +28,6 @@ async function fetchServer(sentence) {
 
 /**
  * output에 색칠하고 나타내기
- * @param errors
  */
 export function setSpellHightlight() {
   if (spellErrors.length === 0) {

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -28,7 +28,7 @@ async function fetchServer(sentence) {
  * @param errors
  */
 export function setHighlightEvent(errors) {
-  if (!errors) {
+  if (errors.length === 0) {
     return;
   }
 
@@ -36,24 +36,21 @@ export function setHighlightEvent(errors) {
   const output = document.getElementById('output');
   let content = output.innerHTML;
   output.innerHTML = ''; // 기존 내용 초기화
-
+  console.log(errors);
   errors.forEach((error) => {
     const token = error.token;
-    const context = error.context;
     const suggestions = error.suggestions.join(', ');
     const info = error.info.replace(/\n/g, ' ').replace(/'/g, '`');
 
-    index = content.indexOf(context, index);
-    if (index !== -1) {
-      const tokenIndex = content.indexOf(token, index);
-      if (tokenIndex !== -1 && tokenIndex < index + context.length) {
-        content =
-          content.substring(0, tokenIndex) +
-          `<span class="highlight red" data-suggestions="${suggestions}" data-info="${info}">${token}</span>` +
-          content.substring(tokenIndex + token.length);
+    const tokenIndex = content.indexOf(token, index);
 
-        index += `<span class="highlight red">${token}</span>`.length;
-      }
+    if (tokenIndex !== -1) {
+      const span = `<span class="highlight red" data-suggestions="${suggestions}" data-info="${info}">${token}</span>`;
+      content =
+        content.substring(0, tokenIndex) +
+        span +
+        content.substring(tokenIndex + token.length);
+      index = tokenIndex + span.length;
     }
   });
 

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -26,16 +26,15 @@ async function fetchServer(sentence) {
 /**
  * output에 색칠하고 나타내기
  * @param errors
- * @param inputText
  */
-function setHighlightEvent(errors, inputText) {
+export function setHighlightEvent(errors) {
   if (!errors) {
     return;
   }
 
-  let content = inputText;
   let index = 0;
   const output = document.getElementById('output');
+  let content = output.innerHTML;
   output.innerHTML = ''; // 기존 내용 초기화
 
   errors.forEach((error) => {
@@ -91,13 +90,14 @@ function debounce(fn, delay) {
   };
 }
 
+export let spellErrors = [];
 /**
  * 맞춤법 검사 실행 부분 디바운싱 도입
  */
 export const spellCheck = debounce(async () => {
   checkLength();
   const inputText = document.getElementById('output').innerHTML;
-  const result = await fetchServer(inputText.replace(/<\/?span[^>]*>/gi, ''));
-  setHighlightEvent(result, inputText);
+  spellErrors = await fetchServer(inputText.replace(/<\/?span[^>]*>/gi, ''));
+  setHighlightEvent(spellErrors);
   setEvent();
-}, 200);
+}, 100);


### PR DESCRIPTION
resolved #42 
## 작업 개요
맞춤법 오류 수정 및 겹칠 때 event 오류 수정

## 작업 사항
1. br 태그로 바뀐 걸 가져오다 보니 맞춤법 검사를 못했던 오류 수정
2. 디바운싱 줄이기 (200ms -> 100ms)
3. 입력 시 이미 구한 error로 다시 highlight 하기 추가
4. index 추적하는 로직 다시 수정하기
5. 똑같은 token에 대해 잘 찾는 방향으로 변경
6. 맞춤법과 긴문장의 겹치는 setEvent를 이름 바꾸기
7. 반영하기 시 다시 맞춤법 검사와 긴 문장 시도하기

## 스크린샷(필수 X)

![kopilot - Chrome 2024-07-29 15-19-00](https://github.com/user-attachments/assets/7d4d3606-e534-4d83-a02e-062131560d27)
![11234](https://github.com/user-attachments/assets/c5f7374c-6122-4b9a-96af-08cd2a692994)
