### PR TITLE
Feature(#8): 긴 문장 감지 기준 설정

### DIFF
--- a/src/clova/clova.controller.ts
+++ b/src/clova/clova.controller.ts
@@ -22,8 +22,8 @@ export class ClovaController {
   }
 
   @Post('/parsed-line')
-  parsedLine(@Body('text') text: string) {
-    return this.parsedSentenceService.getParsedSentence(text);
+  parsedLine(@Body('text') text: string, @Body('length') length: number) {
+    return this.parsedSentenceService.getParsedSentence(text, length);
   }
 
   @Post('/feedback')

--- a/src/clova/feedback.service.ts
+++ b/src/clova/feedback.service.ts
@@ -4,12 +4,12 @@ import { LONG_DESCRIPTION_DETAILS } from './constants/clova-request-body-details
 import {
   ChatMessage,
   ChatRole,
-} from './type/clova-chat-completions/chat-message.type';
-import { ClovaChatCompletionsRequestBody } from './type/clova-chat-completions/request-body.type';
-import { ClovaChatCompletionsResponseBody } from './type/clova-chat-completions/response-body.type';
-import { ClovaCompletionsResponseBody } from './type/clova-completions/response-body.type';
-import { ClovaRequestHeader } from './type/clova-request-header.type';
-import { PartialModificationResult } from './type/partial-response.type';
+} from './types/clova-chat-completions/chat-message.type';
+import { ClovaChatCompletionsRequestBody } from './types/clova-chat-completions/request-body.type';
+import { ClovaChatCompletionsResponseBody } from './types/clova-chat-completions/response-body.type';
+import { ClovaCompletionsResponseBody } from './types/clova-completions/response-body.type';
+import { ClovaRequestHeader } from './types/clova-request-header.type';
+import { PartialModificationResult } from './types/partial-response.type';
 import { requestPost } from './utils/request-api';
 
 @Injectable()

--- a/src/clova/feedback.service.ts
+++ b/src/clova/feedback.service.ts
@@ -4,12 +4,12 @@ import { LONG_DESCRIPTION_DETAILS } from './constants/clova-request-body-details
 import {
   ChatMessage,
   ChatRole,
-} from './types/clova-chat-completions/chat-message.type';
-import { ClovaChatCompletionsRequestBody } from './types/clova-chat-completions/request-body.type';
-import { ClovaChatCompletionsResponseBody } from './types/clova-chat-completions/response-body.type';
-import { ClovaCompletionsResponseBody } from './types/clova-completions/response-body.type';
-import { ClovaRequestHeader } from './types/clova-request-header.type';
-import { PartialModificationResult } from './types/partial-response.type';
+  ClovaChatCompletionsRequestBody,
+  ClovaChatCompletionsResponseBody,
+  ClovaCompletionsResponseBody,
+  ClovaRequestHeader,
+  PartialModificationResult,
+} from './types';
 import { requestPost } from './utils/request-api';
 
 @Injectable()

--- a/src/clova/parsedSentence.service.ts
+++ b/src/clova/parsedSentence.service.ts
@@ -14,13 +14,12 @@ export class ParsedSentenceService {
     'Content-Type': 'application/json',
   };
 
-  async getParsedSentence(text: string): Promise<any> {
+  async getParsedSentence(text: string, length: number): Promise<any> {
     const data = {
       messages: [
         {
           role: 'system',
-          content:
-            '문장이 100자가 넘는다면, 한 문장을 100자 미만으로 나눠줘. 결과는 나뉜 문장만을 줄글로 보여줘.',
+          content: `문장이 ${length}자가 넘는다면, 한 문장을 ${length}자 미만으로 나눠줘. 결과는 나뉜 문장만을 줄글로 보여줘.`,
         },
         {
           role: 'user',

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -20,7 +20,7 @@
     <div id='output'></div>
     <div class='info-box'>
       <ul>
-        <li class='yellow'>
+        <li class='yellow' id='longsentence-setting'>
           <img src='/images/circle.png'/>
           긴 문장
           <span class="tooltip">긴 문장을 노란색으로 하이라이팅해요.<br/>클릭하여 분리된 문장을 확인하고 고쳐보세요!</span>

--- a/views/javascript/components/textarea.js
+++ b/views/javascript/components/textarea.js
@@ -1,7 +1,4 @@
-import {
-  checkLength,
-  setLongSentenceEvent,
-} from '../longSentence/longSentence.js';
+import { LongSentence } from '../longSentence/longSentence.js';
 import { setSpellHightlight, spellCheck } from '../spell/spellCheck.js';
 
 export class Textarea {
@@ -53,9 +50,10 @@ export class Textarea {
       this.#restoreNextCursorPointer();
       event.preventDefault();
     }
-    checkLength(event);
+
+    LongSentence.checkLength(event);
     setSpellHightlight();
-    setLongSentenceEvent();
+    LongSentence.setLongSentenceEvent();
   }
 
   handleKeydownEvent(event) {

--- a/views/javascript/index.js
+++ b/views/javascript/index.js
@@ -3,6 +3,7 @@ import { CursorBox } from './components/cursorBox.js';
 import { FeedbackPopup } from './components/feedbackPopup.js';
 import { Textarea } from './components/textarea.js';
 import { WritingTool } from './components/writingTool.js';
+import { showSetting } from './longSentence/popup.js';
 
 const textareaHolder = document.getElementById('textarea');
 
@@ -39,3 +40,6 @@ const feedbackPopup = new FeedbackPopup(
 feedbackBtn.addEventListener('click', () => {
   feedbackPopup.show();
 });
+
+const setting = document.getElementById('longsentence-setting');
+setting.addEventListener('click', (event) => showSetting(event));

--- a/views/javascript/longSentence/longSentence.js
+++ b/views/javascript/longSentence/longSentence.js
@@ -1,52 +1,66 @@
 import { showSuggestion } from './popup.js';
 
-export const parseSentence = async (sentence) => {
-  const url = 'http://localhost:3000/clova/parsed-line';
-  const data = {
-    text: sentence,
+export class LongSentence {
+  static #length = 100;
+
+  static setLength = (length) => {
+    this.#length = length;
   };
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(data),
-  });
-  return await response.text();
-};
+  static getLength = () => {
+    return this.#length;
+  };
 
-export const changePage = (span, textarea, output) => {
-  const parsedText = span.dataset.tooltip;
-  const textNode = document.createTextNode(parsedText);
-  span.parentNode.replaceChild(textNode, span);
-  textarea.value = output.innerText;
-};
+  static parseSentence = async (sentence) => {
+    const url = 'http://localhost:3000/clova/parsed-line';
+    const data = {
+      text: sentence,
+      length: this.#length,
+    };
 
-export const setLongSentenceEvent = () => {
-  const tag = document.querySelectorAll('.highlight.yellow');
-  tag.forEach((span) => {
-    span.addEventListener('click', (event) => {
-      showSuggestion(event, span);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
     });
-  });
-};
+    return await response.text();
+  };
 
-export const checkLength = () => {
-  const textarea = document.getElementById('textarea');
-  const output = document.getElementById('output');
+  static changePage = (span, textarea, output) => {
+    const parsedText = span.dataset.tooltip;
+    const textNode = document.createTextNode(parsedText);
+    span.parentNode.replaceChild(textNode, span);
+    textarea.value = output.innerText;
+  };
 
-  const text = textarea.value;
-  const sentences = text.match(/[^\.!\?]+[\.!\?]+|[^\.!\?]+$/g);
-  let outputContent = '';
-  if (sentences) {
-    sentences.forEach((sentence) => {
-      if (sentence.length >= 20) {
-        sentence = '<span class="highlight yellow">' + sentence + '</span>';
-      }
-      outputContent += sentence;
+  static setLongSentenceEvent = () => {
+    const tag = document.querySelectorAll('.highlight.yellow');
+    tag.forEach((span) => {
+      span.addEventListener('click', (event) => {
+        showSuggestion(event, span);
+      });
     });
+  };
 
-    output.innerHTML = outputContent.replace(/\n/g, '<br>');
-  }
-};
+  static checkLength = () => {
+    const textarea = document.getElementById('textarea');
+    const output = document.getElementById('output');
+
+    const text = textarea.value;
+    const sentences = text.match(/[^\.!\?]+[\.!\?]+|[^\.!\?]+$/g);
+    let outputContent = '';
+    if (sentences) {
+      sentences.forEach((sentence) => {
+        if (sentence.length >= this.#length) {
+          sentence = '<span class="highlight yellow">' + sentence + '</span>';
+        }
+        outputContent += sentence;
+      });
+
+      output.innerHTML = outputContent.replace(/\n/g, '<br>');
+      this.setLongSentenceEvent();
+    }
+  };
+}

--- a/views/javascript/longSentence/popup.js
+++ b/views/javascript/longSentence/popup.js
@@ -34,6 +34,7 @@ export async function showSetting(event) {
   const outputPopup = new OutputPopup('긴 문장 기준을 입력하세요.', '', () => {
     const input = document.getElementById('lengthInput');
     LongSentence.setLength(input.value);
+    LongSentence.checkLength();
     outputPopup.hide();
   });
   const outputContent = document.getElementById('output-popup-content');

--- a/views/javascript/longSentence/popup.js
+++ b/views/javascript/longSentence/popup.js
@@ -1,6 +1,6 @@
 import { OutputPopup } from '../components/outputPopup.js';
 import { spellCheck } from '../spell/spellCheck.js';
-import { parseSentence } from './longSentence.js';
+import { LongSentence } from './longSentence.js';
 
 export async function showSuggestion(event, span) {
   event.stopPropagation(); // 이벤트 전파 막기
@@ -15,7 +15,7 @@ export async function showSuggestion(event, span) {
     </div>`;
   outputPopup.hideButton();
 
-  const suggestion = await parseSentence(span.innerText);
+  const suggestion = await LongSentence.parseSentence(span.innerText);
   outputPopup.set('긴 문장을 다음과 같이 수정해보세요.', suggestion, () => {
     span.outerHTML = suggestion;
     const output = document.getElementById('output');
@@ -26,4 +26,19 @@ export async function showSuggestion(event, span) {
     textarea.focus(); // 커서를 textarea로 이동
   });
   outputPopup.showButton();
+}
+
+export async function showSetting(event) {
+  event.stopPropagation(); // 이벤트 전파 막기
+
+  const outputPopup = new OutputPopup('긴 문장 기준을 입력하세요.', '', () => {
+    const input = document.getElementById('lengthInput');
+    LongSentence.setLength(input.value);
+    outputPopup.hide();
+  });
+  const outputContent = document.getElementById('output-popup-content');
+  outputContent.innerHTML = `
+  <input id="lengthInput" type="number" style="width: 100%;" value=${LongSentence.getLength()}>
+  `;
+  outputPopup.show();
 }

--- a/views/javascript/longSentence/popup.js
+++ b/views/javascript/longSentence/popup.js
@@ -31,15 +31,15 @@ export async function showSuggestion(event, span) {
 export async function showSetting(event) {
   event.stopPropagation(); // 이벤트 전파 막기
 
-  const outputPopup = new OutputPopup('긴 문장 기준을 입력하세요.', '', () => {
-    const input = document.getElementById('lengthInput');
-    LongSentence.setLength(input.value);
-    LongSentence.checkLength();
-    outputPopup.hide();
-  });
-  const outputContent = document.getElementById('output-popup-content');
-  outputContent.innerHTML = `
-  <input id="lengthInput" type="number" style="width: 100%;" value=${LongSentence.getLength()}>
-  `;
+  const outputPopup = new OutputPopup(
+    '긴 문장 기준을 입력하세요.',
+    `<input id="lengthInput" type="number" style="width: 100%;" value=${LongSentence.getLength()}>`,
+    () => {
+      const input = document.getElementById('lengthInput');
+      LongSentence.setLength(input.value);
+      LongSentence.checkLength();
+      outputPopup.hide();
+    },
+  );
   outputPopup.show();
 }

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -1,7 +1,4 @@
-﻿import {
-  checkLength,
-  setLongSentenceEvent,
-} from '../longSentence/longSentence.js';
+﻿import { LongSentence } from '../longSentence/longSentence.js';
 import { showSuggestion } from './popup.js';
 
 /**
@@ -94,9 +91,9 @@ export let spellErrors = [];
  * 맞춤법 검사 실행 부분 디바운싱 도입
  */
 export const spellCheck = debounce(async () => {
-  checkLength();
+  LongSentence.checkLength();
   const inputText = document.getElementById('output').innerHTML;
   spellErrors = await fetchServer(inputText.replace(/<\/?span[^>]*>/gi, ''));
   setSpellHightlight();
-  setLongSentenceEvent();
+  LongSentence.setLongSentenceEvent();
 }, 100);


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

close #8 

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- [x] 긴 문장 기준 사람들마다 입력 받을 수 있게 하기(default는 100자)
- [x] 긴 문장 기준 수정됐을 때, 재검사 진행하도록 수정
    - 예를 들어서 100자에서 200자의 경우 100자에는 감지되었던 게 200자일 때는 안 되어야 함. 
- [x] `src/clova/type` 에서 `src/clova/types` 로 백엔드 파트에서 폴더 이름이 바뀌면서 `src/clova/feedback.service.ts` 에서 import 경로가 수정이 안 되는 부분 수정
    - 이 부분은 다른 분들은 잘 되셨을지 모르겠는데, 저는 반영이 안 되어 있어서 바꿔줬습니다!
    - 제가 변경한 부분이 아니라서 문제 있으면 확인 부탁드립니다 😀

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

- `LengthCheck` 부분에서 기존에는 함수로만 되어있었는데, 긴 문장 기준이라는 상태까지 같이 관리하게 되면서 class로 바꿨습니다.
    그런데 매번 호출할 때마다 객체로 new로 생성해서 만들 필요는 없을 거 같아서 static으로 했는데, 그러다보니 class 안에 다 static 밖에 없어져서...🥲😇 더 좋게 개선할 방법이 있을까요?

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
<img width="678" alt="Untitled (3)" src="https://github.com/user-attachments/assets/05cb12d7-d7f8-4c74-a0d4-6edc62a9d558">
