### PR TITLE
Fix(#61): 맞춤법 피드백 버그 수정

### DIFF
--- a/views/javascript/components/feedbackPopup.js
+++ b/views/javascript/components/feedbackPopup.js
@@ -58,7 +58,7 @@ export class FeedbackPopup extends BasePopup {
     );
     const feedback = await response.json();
 
-    feedbackContent.innerText = feedback;
+    feedbackContent.innerText = feedback.result;
   }
 
   handleCancel() {

--- a/views/javascript/spell/popup.js
+++ b/views/javascript/spell/popup.js
@@ -7,7 +7,7 @@ import { spellCheck } from './spellCheck.js';
  * @param suggestions 제안
  * @param info 정보
  */
-export function showSuggestion(event, element, suggestion) {
+export function showSuggestion(event, element, idx) {
   event.stopPropagation(); // 이벤트 전파 막기
 
   const outputPopup = new OutputPopup(
@@ -15,7 +15,7 @@ export function showSuggestion(event, element, suggestion) {
     `
       <div class="suggestion-edit-container">
         <div class="suggestion-edit-instructions">${element.innerText}</div>
-        <input type="text" id="suggestion-edit" class="suggestion-edit" value="${suggestion}">
+        <input type="text" id="suggestion-edit" class="suggestion-edit" value="${element.getAttribute('data-suggestions')}">
       </div>
     `,
     () => {
@@ -24,7 +24,7 @@ export function showSuggestion(event, element, suggestion) {
       const output = document.getElementById('output');
       const textarea = document.getElementById('textarea');
       textarea.value = output.innerText;
-      spellCheck.performSpellCheck(); // 반영하기 클릭 시 다시 맞춤법 검사
+      spellCheck.removeErrorByIndex(idx);
       outputPopup.hide();
       textarea.focus(); // 커서를 textarea로 이동
     },

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -33,13 +33,9 @@ class SpellCheck {
   }
 
   #setSpellEvent() {
-    document.querySelectorAll('.highlight.red').forEach((element) => {
+    document.querySelectorAll('.highlight.red').forEach((element, idx) => {
       element.addEventListener('click', (event) => {
-        showSuggestion(
-          event,
-          element,
-          element.getAttribute('data-suggestions'),
-        );
+        showSuggestion(event, element, idx);
       });
     });
   }
@@ -79,6 +75,10 @@ class SpellCheck {
       'spell error',
     );
     this.#spellErrors = await response.json();
+    // 삭제하기 위해 index 추가
+    this.#spellErrors = this.#spellErrors.map((error, idx) => {
+      return { ...error, id: idx };
+    });
   }
 
   async performSpellCheck() {
@@ -101,6 +101,11 @@ class SpellCheck {
 
   #getErrorCount() {
     return this.#spellErrors.length;
+  }
+
+  removeErrorByIndex(id) {
+    this.#spellErrors = this.#spellErrors.filter((error) => error.id !== id);
+    this.#updateErrorCount();
   }
 }
 

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -5,6 +5,7 @@ import { showSuggestion } from './popup.js';
 class SpellCheck {
   #spellErrors = [];
   #output = document.getElementById('output');
+  #textarea = document.getElementById('textarea');
   #errorCount = document.getElementById('error-count');
 
   setSpellHighlight() {
@@ -82,9 +83,10 @@ class SpellCheck {
   }
 
   async performSpellCheck() {
+    this.#output.innerHTML = this.#textarea.value;
     const longSentence = LongSentence.getInstance();
     longSentence.checkLength();
-    this.#updateSpellErrors();
+    await this.#updateSpellErrors();
     this.setSpellHighlight();
     longSentence.setLongSentenceEvent();
   }

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -78,7 +78,7 @@ class SpellCheck {
     this.#spellErrors = await response.json();
     // 삭제하기 위해 index 추가
     this.#spellErrors = this.#spellErrors.map((error, idx) => {
-      return { ...error, id: idx };
+      return { ...error, idx };
     });
   }
 
@@ -105,8 +105,8 @@ class SpellCheck {
     return this.#spellErrors.length;
   }
 
-  removeErrorByIndex(id) {
-    this.#spellErrors = this.#spellErrors.filter((error) => error.id !== id);
+  removeErrorByIndex(idx) {
+    this.#spellErrors = this.#spellErrors.filter((error) => error.idx !== idx);
     this.#updateErrorCount();
   }
 }


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->
resolved #61 
## 작업 개요
5주차 버그 리포트 수정

## 작업 사항
### 맞춤법
맞춤법 반영하고 개수 update
맞춤법이 복사 붙여넣기 후에는 진행되지 않음 
### 피드백
object를 반환 .result를 추가해서 object 안하게 수정하기

## 고민한 점들(필수 X)
1. 맞춤법 update하기 위해 index 추가
```javascript
// 삭제하기 위해 index 추가
this.#spellErrors = this.#spellErrors.map((error, idx) => {
  return { ...error, idx };
});

removeErrorByIndex(idx) {
  this.#spellErrors = this.#spellErrors.filter((error) => error.idx !== idx);
  this.#updateErrorCount();
}
```
2. 복사 붙여넣기를 하거나 잘 검사가 안되는 경우 
`await`가 코드 정리하면서 없어져서 잘 안되고 있었다.
```javascript
async performSpellCheck() {
  this.#output.innerHTML = this.#textarea.value;
  const longSentence = LongSentence.getInstance();
  longSentence.checkLength();
  await this.#updateSpellErrors();
  this.setSpellHighlight();
  longSentence.setLongSentenceEvent();
}
```
