### PR TITLE
Fix(#8): 긴 문장 교정 시 줄바꿈 유지 되도록 수정

### DIFF
--- a/views/javascript/longSentence/longSentence.js
+++ b/views/javascript/longSentence/longSentence.js
@@ -70,8 +70,9 @@ export class LongSentence {
 
   checkLength = () => {
     const output = document.getElementById('output');
-    const text = document.getElementById('textarea').value;
+    let text = document.getElementById('textarea').value;
 
+    text = text.replace(/\n/g, '<br>');
     const sentences = text.match(/[^\.!\?\n\r]+[\.!\?\n\r]+|[^\.!\?\n\r]+$/g);
     let outputContent = '';
     this.resetCounter();

--- a/views/javascript/longSentence/longSentence.js
+++ b/views/javascript/longSentence/longSentence.js
@@ -6,12 +6,16 @@ export class LongSentence {
   #length = 100;
   #numOfLongSentence = 0;
   #count;
+  #textarea;
+  #output;
 
   constructor() {
     if (LongSentence.#instance) {
       return LongSentence.#instance;
     }
     this.#count = document.getElementById('longsentence-count');
+    this.#textarea = document.getElementById('textarea');
+    this.#output = document.getElementById('output');
     LongSentence.#instance = this;
   }
 
@@ -69,10 +73,9 @@ export class LongSentence {
   };
 
   checkLength = () => {
-    const output = document.getElementById('output');
-    let text = document.getElementById('textarea').value;
-
+    let text = this.#textarea.value;
     text = text.replace(/\n/g, '<br>');
+
     const sentences = text.match(/[^\.!\?\n\r]+[\.!\?\n\r]+|[^\.!\?\n\r]+$/g);
     let outputContent = '';
     this.resetCounter();
@@ -85,7 +88,7 @@ export class LongSentence {
         outputContent += sentence;
       });
 
-      output.innerHTML = outputContent.replace(/\n/g, '<br>');
+      this.#output.innerHTML = outputContent.replace(/\n/g, '<br>');
       this.#count.innerText = this.#numOfLongSentence;
       this.setLongSentenceEvent();
     }


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

긴 문장 교정 시 줄바꿈 유지 되도록 수정했습니다.


## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

기존에 문장 분리를 `.`/`?`/`!`/`줄바꿈` 기준으로 진행했습니다. 정규식을 파싱할 때 줄바꿈이 감지가 잘 안 돼서 정규식으로 문장을 파싱하기 전에 

```javascript
text.replace(/\n/g, '<br>');
```

줄바꿈을 <br> 태그로 바꿔줘서 정규식 파싱으로 줄바꿈이 없어지지 않도록 수정했습니다.