### PR TITLE
Refactor(#95): 어미 자동 완성 update 중에도 보이도록 수정

### DIFF
--- a/views/css/autoComplete.css
+++ b/views/css/autoComplete.css
@@ -6,14 +6,16 @@
   justify-content: center;
   align-items: center;
 
-  height: 1.5rem;
-  padding: 2px 5px;
+  padding: 0.2rem;
 
-  border: var(--border-size--thin) solid var(--font-color--tertiary);
+  border: var(--border-size--thin) solid var(--border-color--dark);
   border-radius: var(--border-radius--small);
 
   background-color: white;
   color: var(--font-color--secondary);
+
+  font-size: var(--font-size--medium);
+  font-family: var(--font-family--editor);
 
   z-index: var(--z-index--high);
   pointer-events: none;

--- a/views/css/index.css
+++ b/views/css/index.css
@@ -7,6 +7,7 @@
   --font-color--tertiary: #555;
 
   --border-color: #e5e5e5;
+  --border-color--dark: #999;
 
   --highlight-red: rgba(255, 0, 0, 0.3);
   --highlight-yellow: rgba(255, 255, 0, 0.5);

--- a/views/javascript/autoComplete/autoCompletion.js
+++ b/views/javascript/autoComplete/autoCompletion.js
@@ -44,37 +44,15 @@ export class AutoCompletion {
       return;
     }
 
-    const autoPointer = this.getPointer();
+    const pointer = this.getPointer();
 
     if (!this.#inputTracker.isComposing()) {
       this.emptyChar();
-      removeIncompleteCallback(autoPointer - 1);
-
-      this.#insertPhraseAndSetCursor(
-        autoPointer - 1,
-        ending,
-        insertPhraseCallback,
-        setNextCursorCallback,
-      );
-      return;
+      removeIncompleteCallback(pointer);
     }
 
-    this.#insertPhraseAndSetCursor(
-      autoPointer,
-      ending,
-      insertPhraseCallback,
-      setNextCursorCallback,
-    );
-  }
-
-  #insertPhraseAndSetCursor(
-    autoPointer,
-    ending,
-    insertPhraseCallback,
-    setNextCursorCallback,
-  ) {
-    insertPhraseCallback(autoPointer, ending);
-    setNextCursorCallback(autoPointer, ending);
+    insertPhraseCallback(pointer, ending);
+    setNextCursorCallback(pointer, ending);
     this.reset();
   }
 
@@ -136,7 +114,7 @@ export class AutoCompletion {
   }
 
   getPointer() {
-    return this.#pointer.get();
+    return this.#pointer.get() - !this.#inputTracker.isComposing();
   }
 
   #showCursorBox(pointer) {

--- a/views/javascript/autoComplete/autoCompletion.js
+++ b/views/javascript/autoComplete/autoCompletion.js
@@ -47,12 +47,35 @@ export class AutoCompletion {
     const autoPointer = this.getPointer();
 
     if (!this.#inputTracker.isComposing()) {
+      this.emptyChar();
       removeIncompleteCallback(autoPointer - 1);
+
+      this.#insertPhraseAndSetCursor(
+        autoPointer - 1,
+        ending,
+        insertPhraseCallback,
+        setNextCursorCallback,
+      );
+      return;
     }
 
+    this.#insertPhraseAndSetCursor(
+      autoPointer,
+      ending,
+      insertPhraseCallback,
+      setNextCursorCallback,
+    );
+  }
+
+  #insertPhraseAndSetCursor(
+    autoPointer,
+    ending,
+    insertPhraseCallback,
+    setNextCursorCallback,
+  ) {
     insertPhraseCallback(autoPointer, ending);
-    this.reset();
     setNextCursorCallback(autoPointer, ending);
+    this.reset();
   }
 
   #getEnding() {

--- a/views/javascript/autoComplete/inputTracker.js
+++ b/views/javascript/autoComplete/inputTracker.js
@@ -50,5 +50,6 @@ export class InputTracker {
 
   isComposing() {
     return this.getChar() !== '' && this.getWord() === '';
+    // return this.#char !== '';
   }
 }

--- a/views/javascript/autoComplete/inputTracker.js
+++ b/views/javascript/autoComplete/inputTracker.js
@@ -2,6 +2,10 @@ export class InputTracker {
   #char = '';
   #word = '';
 
+  getChar() {
+    return this.#char;
+  }
+
   hasChar() {
     return this.#char;
   }
@@ -37,5 +41,14 @@ export class InputTracker {
 
   backspaceWord() {
     this.#word = this.#word.slice(0, -1);
+  }
+
+  reset() {
+    this.#char = '';
+    this.#word = '';
+  }
+
+  isComposing() {
+    return this.getChar() !== '' && this.getWord() === '';
   }
 }

--- a/views/javascript/autoComplete/inputTracker.js
+++ b/views/javascript/autoComplete/inputTracker.js
@@ -50,6 +50,5 @@ export class InputTracker {
 
   isComposing() {
     return this.getChar() !== '' && this.getWord() === '';
-    // return this.#char !== '';
   }
 }

--- a/views/javascript/autoComplete/pointer.js
+++ b/views/javascript/autoComplete/pointer.js
@@ -11,7 +11,7 @@ export class Pointer {
     this.#pointer = pointer;
   }
 
-  empty() {
+  reset() {
     this.#pointer = INITIAL_POINTER;
   }
 }

--- a/views/javascript/components/textarea.js
+++ b/views/javascript/components/textarea.js
@@ -2,10 +2,10 @@ import { KEY } from '../constants/eventKey.js';
 import { LongSentence } from '../longSentence/longSentence.js';
 import { spellCheck } from '../spell/spellCheck.js';
 import { versionStorage } from '../storage/versionStorage.js';
-import { ScrollTracker } from '../utils/ScrollTracker.js';
 import { CharChecker } from '../utils/charChecker.js';
 import { CharCounter } from '../utils/charCounter.js';
 import { KeyChecker } from '../utils/keyChecker.js';
+import { ScrollTracker } from '../utils/scrollTracker.js';
 import { BaseComponent } from './baseComponent.js';
 
 export class Textarea extends BaseComponent {

--- a/views/javascript/components/textarea.js
+++ b/views/javascript/components/textarea.js
@@ -66,13 +66,8 @@ export class Textarea extends BaseComponent {
 
     this.#update();
 
-    // FIXME
-    /**
-     * 1. 개발자 도구를 열거나 반응형으로 떨어졌을 때
-     * 2. 스크롤이 될 정도로 긴 글의 마지막 줄에서 스크롤이 살짝 안 맞음
-     * */
     const scrollTop = this.#scrollTracker.getScrollTop();
-    if (scrollTop !== null) {
+    if (scrollTop !== null && !event.bubbles) {
       this.holder.scrollTop = scrollTop;
     }
   }

--- a/views/javascript/utils/ScrollTracker.js
+++ b/views/javascript/utils/ScrollTracker.js
@@ -26,20 +26,19 @@ export class ScrollTracker {
     const currScrollHeight = this.#holder.scrollHeight;
 
     const lineHeight = DomManager.calculateLineHeight(this.#holder);
-    const maxScrollTop = this.#calculateScrollTop(
-      currScrollHeight,
-      lineHeight,
-      clientHeight,
-    );
-
     if (
       this.#isLastLine(scrollTop, clientHeight, currScrollHeight, lineHeight)
     ) {
-      // FIXME 약간의 흔들림 문제로 lineHeight 추가 (추후 원인 파악 필요)
-      this.#scrollTop = maxScrollTop + lineHeight;
+      this.#scrollTop = currScrollHeight;
       return;
     }
+
     const diff = currScrollHeight - this.#prevScrollHeight;
+    const maxScrollTop = this.#calculateScrollTop(
+      currScrollHeight,
+      clientHeight,
+      lineHeight,
+    );
     this.#scrollTop = Math.min(scrollTop + diff, maxScrollTop);
   }
 
@@ -50,8 +49,8 @@ export class ScrollTracker {
     );
   }
 
-  #calculateScrollTop(scrollHeight, lineHeight, clientHeight) {
-    return scrollHeight + lineHeight - clientHeight;
+  #calculateScrollTop(scrollHeight, clientHeight, lineHeight) {
+    return scrollHeight - clientHeight + lineHeight;
   }
 
   #getPositionBeforeLastNLine(scrollHeight, lineHeight, count = 1) {


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved: #95 

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

IME 조합 문자 update 중에도 자동 완성 로직을 수행하도록 수정한다

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 기존에는 `compositionend` 이벤트에 리스너를 달았기 때문에 IME 조합 문자가 모두 완성되어야 비즈니스 로직을 수행
- `compositionupdate` 이벤트로 변경하여 문자 조합 중에도 자동 완성 로직 수행 (+ 그에 따른 비즈니스 로직 전반적인 수정)

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->


## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
![image](https://github.com/user-attachments/assets/c0c88bdf-34f5-4195-b7b0-15df7c69a48d)

`했` 밑에 밑줄 존재 -> 아직 조합 중 -> 이에 대해서도 자동 완성 제공