### PR TITLE
Feature(#92): 반복 어휘 탐지

### DIFF
--- a/src/clova/clova.controller.ts
+++ b/src/clova/clova.controller.ts
@@ -13,7 +13,7 @@ export class ClovaController {
     private readonly partialModification: PartialModificationService,
     private readonly parsedSentenceService: ParsedSentenceService,
     private readonly feedbackService: FeedbackService,
-    private readonly repeatedWordService: RepetitiveWordService,
+    private readonly repetitiveWordService: RepetitiveWordService,
   ) {}
 
   @Post('/partial-modification')
@@ -39,8 +39,8 @@ export class ClovaController {
     return this.feedbackService.getResult(tone, purpose, text);
   }
 
-  @Post('/repeated-word')
-  detectRepeatedWord(@Body('text') text: string) {
-    return this.repeatedWordService.getRepeatedWord(text);
+  @Post('/repetitive-word')
+  detectRepetitiveWord(@Body('text') text: string) {
+    return this.repetitiveWordService.getRepetitiveWord(text);
   }
 }

--- a/src/clova/repetitive-word.service.ts
+++ b/src/clova/repetitive-word.service.ts
@@ -11,7 +11,7 @@ export class RepetitiveWordService {
   private readonly headers: ClovaRequestHeader =
     ClovaChatCompletionsRequestHeadersForRepetitiveWord;
 
-  public async getRepeatedWord(text: string) {
+  public async getRepetitiveWord(text: string) {
     const data = ClovaRequestBodyTransformer.makeRepitiveWordCommand(text);
 
     const res: any = await requestPost(this.apiUrl, data, this.headers);

--- a/views/css/repetitiveWord.css
+++ b/views/css/repetitiveWord.css
@@ -2,7 +2,7 @@
   background-color: var(--highlight-green);
 }
 
-#repeative-btn {
+#repetitive-btn {
   padding: 0.5rem;
 
   font-size: var(--font-size--small);

--- a/views/css/repetitiveWord.css
+++ b/views/css/repetitiveWord.css
@@ -10,3 +10,7 @@
   border: var(--primary-color) var(--border-size--thin) solid;
   border-radius: var(--border-radius--large);
 }
+
+.green-text {
+  color: green;
+}

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -31,7 +31,7 @@
       <div class='title'>교정 결과</div>
       <div class='detail'>색칠된 부분을 클릭하여 글을 수정해보세요!</div>
       <div class='icon-btn-group'>
-        <div id="repeative-btn">반복되는 단어</div>
+        <div id="repetitive-btn">반복되는 단어</div>
       </div>
     </div>
     <div id='output'></div>

--- a/views/javascript/longSentence/longSentence.js
+++ b/views/javascript/longSentence/longSentence.js
@@ -74,7 +74,7 @@ export class LongSentence {
 
   checkLength = () => {
     let text = this.#textarea.value;
-    const sentences = text.match(/[^\.!\?\n\r]*(?:[\.!\?\n\r]+)+/g);
+    const sentences = text.match(/[^\.!\?\n\r]*(?:[\.!\?\n\r]+|$)+/g);
 
     let outputContent = '';
     this.resetCounter();

--- a/views/javascript/repetitiveWord/popup.js
+++ b/views/javascript/repetitiveWord/popup.js
@@ -43,12 +43,13 @@ export class RepetitiveWordPopup {
 
   showNewWord(data, func) {
     this.#radioBtn = new RadioBtnGroup(this.#holder);
-    this.#radioBtn.addButtons(data.result, 'repetitive');
+    this.#radioBtn.addButtons(data, 'repetitive');
 
     this.#popup.set('다음 단어로 바꿔보세요.', null, () => {
       func(this.#radioBtn.getSelectedBtn());
       this.#popup.hide();
     });
+    this.#popup.show();
     this.showRadioBtn();
   }
 

--- a/views/javascript/repetitiveWord/popup.js
+++ b/views/javascript/repetitiveWord/popup.js
@@ -4,9 +4,11 @@ import { RadioBtnGroup } from '../components/radioBtnGroup.js';
 export class RepetitiveWordPopup {
   #popup;
   #radioBtn;
+  #holder;
 
   constructor() {
     this.#popup = new OutputPopup();
+    this.#holder = this.#popup.holder.querySelector('.radio-btn-group');
   }
 
   showLoading(event, text) {
@@ -21,20 +23,8 @@ export class RepetitiveWordPopup {
     </div>`,
       null,
     );
+    this.hideRadioBtn();
     this.#popup.show();
-    this.#popup.hideButton();
-  }
-
-  showPopup(result, func) {
-    this.#popup.set(
-      '반복되는 단어는 다음과 같습니다.',
-      result.join(', '),
-      () => {
-        func(result);
-        this.#popup.hide();
-      },
-    );
-    this.#popup.showButton();
   }
 
   denyPopup() {
@@ -52,15 +42,23 @@ export class RepetitiveWordPopup {
   }
 
   showNewWord(data, func) {
-    const holder = this.#popup.holder.querySelector('.radio-btn-group');
-    this.#radioBtn = new RadioBtnGroup(holder);
+    this.#radioBtn = new RadioBtnGroup(this.#holder);
     this.#radioBtn.addButtons(data.result, 'repetitive');
 
     this.#popup.set('다음 단어로 바꿔보세요.', null, () => {
       func(this.#radioBtn.getSelectedBtn());
       this.#popup.hide();
     });
+    this.showRadioBtn();
+  }
+
+  hideRadioBtn() {
+    this.#popup.hideButton();
+    this.#holder.style.display = 'none';
+  }
+
+  showRadioBtn() {
     this.#popup.showButton();
-    this.#popup.show();
+    this.#holder.style.display = 'flex';
   }
 }

--- a/views/javascript/repetitiveWord/repetitiveWord.js
+++ b/views/javascript/repetitiveWord/repetitiveWord.js
@@ -77,23 +77,24 @@ export class RepetitiveWord {
       return acc.replace(regex, `<span class="highlight green">${word}</span>`);
     }, content);
 
+    result.forEach(async (data) => {
+      const alternative = await this.getWords(data);
+      localStorage.setItem(data, JSON.stringify(alternative.result));
+    });
+
     this.#output.innerHTML = content;
 
     this.#output.querySelectorAll('.highlight.green').forEach((element) => {
       element.addEventListener('click', async (event) => {
-        this.#popup.showLoading(event, '대체어를 불러오는 중입니다...');
         this.#clickedElement = event.target;
-        const data = await this.getWords(event.target);
-        this.#popup.showNewWord(data, this.updateSelectedValue);
+        const data = localStorage.getItem(event.target.innerText);
+        this.#popup.showNewWord(JSON.parse(data), this.updateSelectedValue);
       });
     });
   }
 
-  getWords = async (target) => {
-    const clickedElement = target;
-    const word = clickedElement.innerText;
-
-    const url = 'http://localhost:3000/clova/partial-modification';
+  getWords = async (word) => {
+    const url = `${window.kopilotConfig.API_BASE_URL}/clova/partial-modification`;
     const body = JSON.stringify({
       input: word,
       command: 'SYNONYM',

--- a/views/javascript/repetitiveWord/repetitiveWord.js
+++ b/views/javascript/repetitiveWord/repetitiveWord.js
@@ -70,7 +70,7 @@ export class RepetitiveWord {
     this.#clickedElement.replaceWith(text);
   };
 
-  async showWord(result) {
+  showWord = async (result) => {
     let content = this.#output.innerHTML;
 
     for (const data of result) {
@@ -97,7 +97,7 @@ export class RepetitiveWord {
         this.#popup.showNewWord(JSON.parse(data), this.updateSelectedValue);
       });
     });
-  }
+  };
 
   getWords = async (word) => {
     const url = `${window.kopilotConfig.API_BASE_URL}/clova/partial-modification`;

--- a/views/javascript/repetitiveWord/repetitiveWord.js
+++ b/views/javascript/repetitiveWord/repetitiveWord.js
@@ -31,7 +31,7 @@ export class RepetitiveWord {
           return;
         }
 
-        this.#btn.innerText = '로딩 중';
+        this.#btn.innerText = '로딩 중...';
         this.#btn.disable = true;
         const words = await this.getRepetitiveWord(text);
 

--- a/views/javascript/repetitiveWord/repetitiveWord.js
+++ b/views/javascript/repetitiveWord/repetitiveWord.js
@@ -30,11 +30,13 @@ export class RepetitiveWord {
           this.#popup.denyPopup();
           return;
         }
-        this.#popup.showLoading(event, '반복되는 단어를 탐지 중입니다...');
+
+        this.#btn.innerText = '로딩 중';
+        this.#btn.disable = true;
         const words = await this.getRepetitiveWord(text);
-        this.#popup.showPopup(words, (words) => {
-          this.showWord(words);
-        });
+
+        this.showWord(words);
+
         this.#btn.innerText = this.#APPLY_BTN_OPTION;
         break;
 

--- a/views/javascript/repetitiveWord/repetitiveWord.js
+++ b/views/javascript/repetitiveWord/repetitiveWord.js
@@ -7,25 +7,25 @@ export class RepetitiveWord {
   #clickedElement;
   #textarea;
   #output;
-  #REPEATIVE_BTN_OPTION = '반복되는 단어';
+  #REPETITIVE_BTN_OPTION = '반복되는 단어';
   #APPLY_BTN_OPTION = '반영하기';
 
   constructor() {
     this.#popup = new RepetitiveWordPopup();
-    this.#btn = document.getElementById('repeative-btn');
+    this.#btn = document.getElementById('repetitive-btn');
     this.#textarea = document.getElementById('textarea');
     this.#output = document.getElementById('output');
 
     this.#btn.addEventListener('click', async (event) =>
-      this.setRepeativeBtnEvent(event, this.#btn.innerText),
+      this.setRepetitiveBtnEvent(event, this.#btn.innerText),
     );
   }
 
-  setRepeativeBtnEvent = async (event, mode) => {
+  setRepetitiveBtnEvent = async (event, mode) => {
     const text = this.#textarea.value;
 
     switch (mode) {
-      case this.#REPEATIVE_BTN_OPTION:
+      case this.#REPETITIVE_BTN_OPTION:
         if (text.length < 200) {
           this.#popup.denyPopup();
           return;
@@ -42,7 +42,7 @@ export class RepetitiveWord {
 
       case this.#APPLY_BTN_OPTION:
         this.#textarea.value = this.#output.innerText;
-        this.#btn.innerText = this.#REPEATIVE_BTN_OPTION;
+        this.#btn.innerText = this.#REPETITIVE_BTN_OPTION;
     }
   };
 

--- a/views/javascript/repetitiveWord/repetitiveWord.js
+++ b/views/javascript/repetitiveWord/repetitiveWord.js
@@ -47,7 +47,7 @@ export class RepetitiveWord {
   };
 
   getRepetitiveWord = async (sentence) => {
-    const url = `${window.kopilotConfig.API_BASE_URL}/clova/repeated-word`;
+    const url = `${window.kopilotConfig.API_BASE_URL}/clova/repetitive-word`;
     const data = {
       text: sentence,
     };
@@ -57,7 +57,7 @@ export class RepetitiveWord {
       'post',
       'json',
       JSON.stringify(data),
-      'repeated word error',
+      'repetitive word error',
     );
     return await response.json();
   };

--- a/views/javascript/repetitiveWord/repetitiveWord.js
+++ b/views/javascript/repetitiveWord/repetitiveWord.js
@@ -63,8 +63,11 @@ export class RepetitiveWord {
   };
 
   updateSelectedValue = (event) => {
-    const textNode = document.createTextNode(event.value);
-    this.#clickedElement.replaceWith(textNode);
+    const text = document.createElement('span');
+    text.classList.add('green-text');
+    text.textContent = event.value;
+
+    this.#clickedElement.replaceWith(text);
   };
 
   showWord(result) {

--- a/views/javascript/repetitiveWord/repetitiveWord.js
+++ b/views/javascript/repetitiveWord/repetitiveWord.js
@@ -35,7 +35,7 @@ export class RepetitiveWord {
         this.#btn.disable = true;
         const words = await this.getRepetitiveWord(text);
 
-        this.showWord(words);
+        await this.showWord(words);
 
         this.#btn.innerText = this.#APPLY_BTN_OPTION;
         break;
@@ -70,17 +70,23 @@ export class RepetitiveWord {
     this.#clickedElement.replaceWith(text);
   };
 
-  showWord(result) {
+  async showWord(result) {
     let content = this.#output.innerHTML;
-    content = result.reduce((acc, word) => {
-      const regex = new RegExp(`(${word})`, 'g');
-      return acc.replace(regex, `<span class="highlight green">${word}</span>`);
-    }, content);
 
-    result.forEach(async (data) => {
+    for (const data of result) {
       const alternative = await this.getWords(data);
-      localStorage.setItem(data, JSON.stringify(alternative.result));
-    });
+      const result = alternative.result;
+
+      if (result.length > 0) {
+        localStorage.setItem(data, JSON.stringify(result));
+
+        const regex = new RegExp(`(${data})`, 'g');
+        content = content.replace(
+          regex,
+          `<span class="highlight green">${data}</span>`,
+        );
+      }
+    }
 
     this.#output.innerHTML = content;
 


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

#92 

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- [x] 반복되는 단어 팝업 삭제
- [x] 교정된 단어 초록색으로 변경
- [x] 반복되는 단어 클릭할 때마다 대체어 받아오지 않고, 처음에 한번에 받아오도록 수정 
- [x] 대체어 반환 안 되면 반복되는 단어 하이라이팅에서 제외
 


## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->

<img width="631" alt="image" src="https://github.com/user-attachments/assets/31dc833d-adb2-471b-934d-e7905f6ee8f5">

바뀐 단어는 `반영하기` 버튼 누르기 전에 교정제안 부분에서 초록색 글자로 바뀝니다.
`반복되는 단어` 버튼 클릭 시에는 팝업을 띄우지 않고 바로 초록색 하이라이팅 해주고 `수정모드`로 들어갑니다.

</br>

https://github.com/user-attachments/assets/954ab6d8-7e62-4eae-86a9-fc47d13a268d
