### PR TITLE
Feature(#103): PR 설정을 자동화한다

### DIFF
--- a/.github/pr-labels.yml
+++ b/.github/pr-labels.yml
@@ -1,0 +1,3 @@
+feature: ['feature/*', 'feat/*']
+bug: ['fix/*', 'bugfix/*', 'hotfix/*']
+refactor: ['refactor/*', 'refact/*']

--- a/.github/workflows/configure-pr.yml
+++ b/.github/workflows/configure-pr.yml
@@ -74,3 +74,25 @@ jobs:
               issue_number: context.payload.number,
               assignees: newAssignees,
             });
+
+  assign-reviewers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Filter reviewers
+        id: filtering
+        uses: actions/github-script@v7
+        if: github.event.pull_request.base.ref != 'release'
+        with:
+          github-token: ${{ secrets.CONFIGURE_PR__PAT }}
+          script: |
+            const sender = context.payload.sender.login;
+            const members = ['kimyu0218', 'tmddus2', 'ttobe'];
+            const reviewers = members.filter((item) => item !== sender).join(',');
+            core.setOutput('reviewers', reviewers);
+
+      - name: Assign reviewers
+        uses: hkusu/review-assign-action@v1.4.0
+        with:
+          github-token: ${{ secrets.CONFIGURE_PR__PAT }}
+          reviewers: ${{ steps.filtering.outputs.reviewers }}

--- a/.github/workflows/configure-pr.yml
+++ b/.github/workflows/configure-pr.yml
@@ -1,7 +1,7 @@
 name: Configure PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 
@@ -14,7 +14,7 @@ jobs:
         uses: deepakputhraya/action-pr-title@master
         with:
           regex: '^(Feature|Fix|Refactor)\(#[\d]+\)\:(.+)$'
-          github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github_token: ${{ secrets.ORG_PAT }}
 
   set-label:
     runs-on: ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
         uses: TimonVS/pr-labeler-action@v5
         with:
           configuration-path: .github/pr-labels.yml
-          repo-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ORG_PAT }}
 
   set-issue:
     needs:
@@ -39,7 +39,7 @@ jobs:
         uses: actions/github-script@v7
         if: github.event.pull_request.base.ref != 'release'
         with:
-          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github-token: ${{ secrets.ORG_PAT }}
           script: |
             const title = context.payload.pull_request.title;
             const issueNumbers = title.match(/#(\d+)/g);
@@ -61,7 +61,7 @@ jobs:
         uses: actions/github-script@v7
         if: github.event.pull_request.base.ref != 'release'
         with:
-          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github-token: ${{ secrets.ORG_PAT }}
           script: |
             const sender = context.payload.sender.login;
             const assignees = context.payload.pull_request.assignees;

--- a/.github/workflows/configure-pr.yml
+++ b/.github/workflows/configure-pr.yml
@@ -1,0 +1,76 @@
+name: Configure PR
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Title
+        uses: deepakputhraya/action-pr-title@master
+        with:
+          regex: '^(Feature|Fix|Refactor)\(#[\d]+\)\:(.+)$'
+          github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
+
+  set-label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Set Label
+        uses: TimonVS/pr-labeler-action@v5
+        with:
+          configuration-path: .github/pr-labels.yml
+          repo-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+
+  set-issue:
+    needs:
+      - check-title
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Issue Number
+        uses: actions/github-script@v7
+        if: github.event.pull_request.base.ref != 'release'
+        with:
+          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          script: |
+            const title = context.payload.pull_request.title;
+            const issueNumbers = title.match(/#(\d+)/g);
+            const prefix = issueNumbers ? issueNumbers.reduce((acc, curr) => `${acc}🚀 resolved ${curr}\n`, "") : '';
+            const body = context.payload.pull_request.body.replace(/(🚀 resolved #\d+)+/g, '');
+
+            github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.number,
+              body: `${prefix}${body}`,
+            });
+
+  set-assignee:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Assignees
+        uses: actions/github-script@v7
+        if: github.event.pull_request.base.ref != 'release'
+        with:
+          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          script: |
+            const sender = context.payload.sender.login;
+            const assignees = context.payload.pull_request.assignees;
+            const newAssignees = assignees ?? [];
+            newAssignees.push(sender);
+
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.number,
+              assignees: newAssignees,
+            });

--- a/.github/workflows/configure-pr.yml
+++ b/.github/workflows/configure-pr.yml
@@ -14,7 +14,7 @@ jobs:
         uses: deepakputhraya/action-pr-title@master
         with:
           regex: '^(Feature|Fix|Refactor)\(#[\d]+\)\:(.+)$'
-          github_token: ${{ secrets.ORG_PAT }}
+          github_token: ${{ secrets.CONFIGURE_PR__PAT }}
 
   set-label:
     runs-on: ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
         uses: TimonVS/pr-labeler-action@v5
         with:
           configuration-path: .github/pr-labels.yml
-          repo-token: ${{ secrets.ORG_PAT }}
+          repo-token: ${{ secrets.CONFIGURE_PR__PAT }}
 
   set-issue:
     needs:
@@ -39,7 +39,7 @@ jobs:
         uses: actions/github-script@v7
         if: github.event.pull_request.base.ref != 'release'
         with:
-          github-token: ${{ secrets.ORG_PAT }}
+          github-token: ${{ secrets.CONFIGURE_PR__PAT }}
           script: |
             const title = context.payload.pull_request.title;
             const issueNumbers = title.match(/#(\d+)/g);
@@ -61,7 +61,7 @@ jobs:
         uses: actions/github-script@v7
         if: github.event.pull_request.base.ref != 'release'
         with:
-          github-token: ${{ secrets.ORG_PAT }}
+          github-token: ${{ secrets.CONFIGURE_PR__PAT }}
           script: |
             const sender = context.payload.sender.login;
             const assignees = context.payload.pull_request.assignees;


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

resolved #103 

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

나중에 release drafter 사용하게 되면 PR이 중요할 것 같아 PR 자동 설정 구현

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 브랜치명을 기반으로 라벨 자동 부착
- PR 제목을 바탕으로 이슈 자동 등록
- PR 날린 사람 자동으로 assignee 등록

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

- 이번에 PR에 라벨을 붙이면서 봤는데 `refactor`를 사용해도 될 것 같은에 `fix`를 많이 사용하고 있는 것 같아요!! 버그만 `fix`로 하고 `refactor`도 많이 사용해보면 어떨까요?
- 혹시라도 조금 유연해졌으면 좋겠다하는 규칙 있으시면 편하게 말씀해주세요! (커밋 메시지에 각 job이 어떤 업무 수행하는지 작성해놓았습니다..!)


## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
![image](https://github.com/user-attachments/assets/b7746d3d-019c-447c-9859-667da487521f)

upstream 브랜치에서 upstream 브랜치로 날렸을 때의 결과입니다. 자동으로 issue, assignee, label을 붙여줍니다.

다만, origin에서 upstream으로 동작하지 않습니다. `pull_request` 대신 `pull_request_target`을 이용하면 된다고 하는데 트리거가 아직 트리거가 안 돼서 머지 후에 확인이 필요할 것 같습니다. 🥹🥹