### PR TITLE
Fix(#115): 맞춤법 하이라이팅 오류 수정

### DIFF
--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -19,14 +19,21 @@ class SpellCheck {
       const token = error.token;
       const suggestions = error.suggestions.join(', ');
 
-      const tokenIndex = content.indexOf(token, index);
-      if (tokenIndex !== -1) {
-        const span = `<span class="highlight red" data-suggestions="${suggestions}">${token}</span>`;
-        content =
-          content.substring(0, tokenIndex) +
-          span +
-          content.substring(tokenIndex + token.length);
-        index = tokenIndex + span.length + 1;
+      const span = `<span class="highlight red" data-suggestions="${suggestions}">${token}</span>`;
+
+      let tokenIndex = content.indexOf(token, index);
+
+      while (tokenIndex !== -1) {
+        if (this.#isToken(content, tokenIndex, token)) {
+          content =
+            content.substring(0, tokenIndex) +
+            span +
+            content.substring(tokenIndex + token.length);
+          index = tokenIndex + span.length + 1;
+          break;
+        }
+
+        tokenIndex = content.indexOf(token, tokenIndex + 1);
       }
     });
 
@@ -34,6 +41,16 @@ class SpellCheck {
     this.#output.innerHTML = content.replace(/\n/g, '<br>');
     this.#setSpellEvent();
     this.#updateErrorCount();
+  }
+
+  #isToken(content, tokenIndex, token) {
+    const nextChar = this.#getNextChar(content, tokenIndex, token);
+    return !nextChar || !/[a-zA-Z가-힣0-9]/.test(nextChar);
+  }
+
+  #getNextChar(content, tokenIndex, token) {
+    const nextCharIndex = tokenIndex + token.length;
+    return nextCharIndex < content.length ? content[nextCharIndex] : null;
   }
 
   #setSpellEvent() {

--- a/views/javascript/spell/spellCheck.js
+++ b/views/javascript/spell/spellCheck.js
@@ -7,6 +7,7 @@ class SpellCheck {
   #output = document.getElementById('output');
   #textarea = document.getElementById('textarea');
   #errorCount = document.getElementById('error-count');
+  #tokenReg = /[a-zA-Z가-힣0-9]/;
 
   setSpellHighlight() {
     let index = 0;
@@ -15,9 +16,9 @@ class SpellCheck {
       return;
     }
 
-    this.#spellErrors.forEach((error) => {
-      const token = error.token;
-      const suggestions = error.suggestions.join(', ');
+    this.#spellErrors.forEach((spellError) => {
+      const token = spellError.token;
+      const suggestions = spellError.suggestions.join(', ');
 
       const span = `<span class="highlight red" data-suggestions="${suggestions}">${token}</span>`;
 
@@ -45,7 +46,7 @@ class SpellCheck {
 
   #isToken(content, tokenIndex, token) {
     const nextChar = this.#getNextChar(content, tokenIndex, token);
-    return !nextChar || !/[a-zA-Z가-힣0-9]/.test(nextChar);
+    return !nextChar || !this.#tokenReg.test(nextChar);
   }
 
   #getNextChar(content, tokenIndex, token) {


### PR DESCRIPTION
🚀 resolved #115















<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->
## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
![2223](https://github.com/user-attachments/assets/7719ec06-decb-4561-b2ec-d6233cb2a995)
맞춤법 하이라이팅 오류

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
1. getNextChar로 다음 값 가져오기
2. nextChar가 없거나, 정규식을 통과하지 못하면 토큰이다.
3. while을 통해 토큰을 찾기

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
다음 문자가 공백인 경우는 중간에 끼는 경우가 있어서 안하고
다음 문자가 어떠한 문자인지 정규식으로 처리를 해보려고 했다.

다음 문자가 없거나, 다음 문자가 공백, 문장부호 등이 아닌 일반 문장일 때 토큰이 아니도록 했다.

사실 뒤에 각종 문자들이 들어가도 맞춤법 감지에서 해당 부분을 포함해서 상관이 없긴 하다.

## 스크린샷(필수 X)
![image](https://github.com/user-attachments/assets/52389be9-b3fa-4313-987a-bf467ac33da8)