### PR TITLE
Fix(#121): 빈 문자열이나 공백 문자 요청을 막는다

### DIFF
--- a/views/css/index.css
+++ b/views/css/index.css
@@ -155,6 +155,10 @@ span.em {
   color: var(--primary-color);
 }
 
+div.white-space-pre-wrap {
+  white-space: pre-wrap;
+}
+
 .title {
   display: flex;
   align-items: center;

--- a/views/css/index.css
+++ b/views/css/index.css
@@ -386,6 +386,10 @@ div.white-space-pre-wrap {
   display: flex;
 }
 
+.radio-btn-group.center {
+  justify-content: center;
+}
+
 .radio-btn-group label {
   display: block;
   cursor: pointer;

--- a/views/css/repetitiveWord.css
+++ b/views/css/repetitiveWord.css
@@ -7,10 +7,13 @@
 
   font-size: var(--font-size--small);
 
-  border: var(--primary-color) var(--border-size--thin) solid;
+  color: var(--secondary-color);
+  background-color: var(--primary-color);
+
   border-radius: var(--border-radius--large);
 }
 
 .green-text {
   color: green;
+  font-weight: 600;
 }

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -13,7 +13,7 @@
     </div>
     <div id='textarea-container'>
       <textarea id='textarea'></textarea>
-      <div id="highlight-container"></div>
+      <div class='white-space-pre-wrap' id="highlight-container"></div>
     </div>
     <div id='cursor-box'></div>
     {{> writing-tool }}
@@ -34,7 +34,7 @@
         <div id="repetitive-btn">반복되는 단어</div>
       </div>
     </div>
-    <div id='output'></div>
+    <div class='white-space-pre-wrap' id='output'></div>
     <div class='info-box'>
       <ul>
         <li class='yellow' id='longsentence-setting'>

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -31,7 +31,7 @@
       <div class='title'>교정 결과</div>
       <div class='detail'>색칠된 부분을 클릭하여 글을 수정해보세요!</div>
       <div class='icon-btn-group'>
-        <div id="repetitive-btn">반복되는 단어</div>
+        <button id="repetitive-btn">반복되는 단어</button>
       </div>
     </div>
     <div class='white-space-pre-wrap' id='output'></div>

--- a/views/javascript/components/editorBox.js
+++ b/views/javascript/components/editorBox.js
@@ -74,7 +74,7 @@ export class EditorBox extends BaseComponent {
   }
 
   #isValidInput(text, command, length) {
-    return text.length >= length || command === DIRECT_COMMAND;
+    return text.trim().length >= length || command === DIRECT_COMMAND;
   }
 
   #showDirectCommandView() {
@@ -82,10 +82,9 @@ export class EditorBox extends BaseComponent {
     super.show();
 
     DomManager.showElement(this.#aiBtn);
-    DomManager.overrideClickEvent(this.#aiBtn, () => {
-      this.#inputBox.hide();
-      this.#request(true);
-    });
+    DomManager.overrideClickEvent(this.#aiBtn, () =>
+      this.#handleAiBtnClickEvent(),
+    );
   }
 
   async #request(stream) {
@@ -115,6 +114,19 @@ export class EditorBox extends BaseComponent {
       const { result } = await response.json();
       this.#handleApi(result);
     }
+  }
+
+  #isValidUserCommand() {
+    return this.#inputBox.getValue().trim().length > 0;
+  }
+
+  #handleAiBtnClickEvent() {
+    if (!this.#isValidUserCommand()) {
+      this.#alertPopup.pop('내용을 입력해주세요');
+      return;
+    }
+    this.#inputBox.hide();
+    this.#request(true);
   }
 
   #handleApi(result) {

--- a/views/partials/components/popup.hbs
+++ b/views/partials/components/popup.hbs
@@ -1,6 +1,6 @@
 <div class='popup {{purpose}} {{type}}' id='{{id}}'>
   <h4 class='title'></h4>
   <div class='content'></div>
-  <div class='radio-btn-group'></div>
+  <div class='radio-btn-group {{ align }}'></div>
   {{> components/button-group }}
 </div>

--- a/views/partials/output-popup.hbs
+++ b/views/partials/output-popup.hbs
@@ -1,6 +1,7 @@
 {{> components/popup
   id='output-popup'
   size='medium'
+  align='center'
   buttons='[
     {"type": "ok", "label": "반영"},
     {"type": "cancel", "label": "취소"}


### PR DESCRIPTION
🚀 resolved #121
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->


## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- `AI에게 직접 요청` 시 빈 문자열을 보낼 수 없도록 구현 (by 팝업 처리)
- 다른 부분 수정 옵션들에 대해서도 `trim`을 통해 앞뒤 공백 제거 후 글자수 검사
- 여러 개의 공백이 유지되도록 CSS 추가

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
