### PR TITLE
Refactor(#126): 히스토리 피드백 UI 수정

### DIFF
--- a/views/css/feedbackSlide.css
+++ b/views/css/feedbackSlide.css
@@ -59,8 +59,9 @@
 }
 
 #feedback-tip .tooltip {
-  width: 18rem;
+  width: 15rem;
   text-align: left;
+  font-size: var(--font-size--x-small);
   transform: translateY(-10%);
   padding: 1rem;
   right: 150%;

--- a/views/css/index.css
+++ b/views/css/index.css
@@ -513,6 +513,7 @@ span.em {
   overflow: auto;
 
   flex-grow: 1;
+  font-family: var(--font-family—editor);
 }
 
 #overlay {

--- a/views/css/storagePopup.css
+++ b/views/css/storagePopup.css
@@ -33,7 +33,7 @@
   border-bottom: 0.1rem solid #eee;
   text-align: center;
   font-size: var(--font-size--small);
-  color: var(--border-color--dark);
+  color: var(--font-color--tertiary);
 }
 
 #version-list li:last-child {
@@ -48,5 +48,5 @@
 #cancel-button {
   width: 100%;
   text-align: right;
-  color: var(--border-color--dark);
+  color: var(--font-color--tertiary);
 }

--- a/views/css/storagePopup.css
+++ b/views/css/storagePopup.css
@@ -33,7 +33,7 @@
   border-bottom: 0.1rem solid #eee;
   text-align: center;
   font-size: var(--font-size--small);
-  color: var(--primary-color);
+  color: var(--border-color--dark);
 }
 
 #version-list li:last-child {
@@ -48,4 +48,5 @@
 #cancel-button {
   width: 100%;
   text-align: right;
+  color: var(--border-color--dark);
 }


### PR DESCRIPTION
🚀 resolved #126
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
히스토리 피드백 UI 수정
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
1. `feedback-content` `font-family-editor` 적용
2. 히스토리 폰트 색상 변경
  `primary-color` -> `--border-color--dark`
3. 피드백 툴팁 폰트 사이즈 설정, 기존 툴팁들과 같은 `x-small`로

## 고민한 점들(필수 X)

## 스크린샷(필수 X)

1. 히스토리 폰트
![b](https://github.com/user-attachments/assets/c89dc8eb-39b6-4e9b-b1ec-7f3a3e7332f2)

2. 툴팁 전
![be](https://github.com/user-attachments/assets/4502ad62-70b9-4295-bdde-5bd8437db20c)

3. 툴팁 후
![image](https://github.com/user-attachments/assets/f8a3e6cc-a9c2-4ec1-9d90-8a3b45960c70)
