### PR TITLE
Fix(#121, #128): 긴 문장 공백 관련 이슈들 해결

### DIFF
--- a/views/javascript/longSentence/longSentence.js
+++ b/views/javascript/longSentence/longSentence.js
@@ -86,7 +86,7 @@ export class LongSentence {
     this.resetCounter();
     if (sentences) {
       sentences.forEach((sentence) => {
-        if (sentence.length >= this.#length) {
+        if (sentence.length.trim() >= this.#length) {
           sentence = '<span class="highlight yellow">' + sentence + '</span>';
           this.#numOfLongSentence++;
         }

--- a/views/javascript/longSentence/longSentence.js
+++ b/views/javascript/longSentence/longSentence.js
@@ -53,7 +53,13 @@ export class LongSentence {
       JSON.stringify(data),
       'long sentence error',
     );
-    return await response.text();
+
+    const trimedSentence = sentence.replace(/^\s+|\s+$/g, '');
+    const parsedSentence = await response.text();
+    return sentence.replace(
+      new RegExp(`(\\s*)${trimedSentence}(\\s*)`),
+      `$1${parsedSentence}$2`,
+    );
   };
 
   changePage = (span, textarea, output) => {


### PR DESCRIPTION
🚀 resolved #128
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

close #128 
resolve #121 

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- 긴 문장 앞뒤로 공백 있으면 파싱 후에도 이를 유지하도록 수정

```javascript
    const trimedSentence = sentence.replace(/^\s+|\s+$/g, '');
    const parsedSentence = await response.text();
    return sentence.replace(
      new RegExp(`(\\s*)${trimedSentence}(\\s*)`),
      `$1${parsedSentence}$2`,
    );
```

문장에서 앞뒤에 공백 있는지 체크한 뒤에, 공백을 유지하면서 문장 부분만 나뉘어진 문장으로 바뀌도록 수정

</br>
</br>

- 긴 문장 앞뒤로 긴 공백이 있어서 긴 문장으로 처리되는 경우 제외

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/7faf8982-3ed1-4ea9-864d-e28049c9373f">

