### PR TITLE
Fix(#130): 자동 완성 위치 바로 뒤에 enter가 있을 때 어미가 다음줄에 표시된다

### DIFF
--- a/views/javascript/autoComplete/autoCompletion.js
+++ b/views/javascript/autoComplete/autoCompletion.js
@@ -53,11 +53,10 @@ export class AutoCompletion {
       removeIncompleteCallback(
         this.#computeRemovePointerForCompositionEnd(ending),
       );
-    } else if (this.#isEndingWithoutComposingCharacter(ending)) {
-      removeIncompleteCallback(
-        this.#computeRemovePointerForCompositionUpdate(),
-      );
-    } else if (this.#isEndingWithoutLastCharacter(ending)) {
+    } else if (
+      this.#isEndingWithoutComposingCharacter(ending) ||
+      this.#isEndingWithoutLastCharacter(ending)
+    ) {
       removeIncompleteCallback(
         this.#computeRemovePointerForCompositionUpdate(),
       );

--- a/views/javascript/autoComplete/autoCompletion.js
+++ b/views/javascript/autoComplete/autoCompletion.js
@@ -57,6 +57,10 @@ export class AutoCompletion {
       removeIncompleteCallback(
         this.#computeRemovePointerForCompositionUpdate(),
       );
+    } else if (this.#isEndingWithoutLastCharacter(ending)) {
+      removeIncompleteCallback(
+        this.#computeRemovePointerForCompositionUpdate(),
+      );
     }
 
     const insertPointer = this.#computeInsertPointer(ending);
@@ -71,7 +75,7 @@ export class AutoCompletion {
 
   #computeRemovePointerForCompositionEnd(ending) {
     return (
-      this.#pointer.get() - 1 + ending === this.#getEndingWithWordAndPhoneme()
+      this.#pointer.get() - 1 + ending == this.#getEndingWithWordAndPhoneme()
     );
   }
 
@@ -81,7 +85,9 @@ export class AutoCompletion {
 
   #computeInsertPointer(ending) {
     return (
-      this.#pointer.get() - this.#isEndingWithoutComposingCharacter(ending)
+      this.#pointer.get() -
+      (this.#isEndingWithoutComposingCharacter(ending) ||
+        this.#isEndingWithoutLastCharacter(ending))
     );
   }
 
@@ -120,6 +126,13 @@ export class AutoCompletion {
     return (
       this.#inputTracker.isWordComposing() &&
       ending === this.#getEndingWithWord()
+    );
+  }
+
+  #isEndingWithoutLastCharacter(ending) {
+    return (
+      this.#inputTracker.isWordComposing() &&
+      ending === this.#getEndingWithLastCharacter()
     );
   }
 

--- a/views/javascript/autoComplete/autoCompletion.js
+++ b/views/javascript/autoComplete/autoCompletion.js
@@ -50,7 +50,6 @@ export class AutoCompletion {
     }
 
     if (!this.#inputTracker.isComposing()) {
-      this.emptyPhoneme();
       removeIncompleteCallback(
         this.#computeRemovePointerForCompositionEnd(ending),
       );

--- a/views/javascript/autoComplete/inputTracker.js
+++ b/views/javascript/autoComplete/inputTracker.js
@@ -43,7 +43,15 @@ export class InputTracker {
     this.#word = '';
   }
 
+  isCharacterComposing() {
+    return this.getPhoneme() && !this.getWord();
+  }
+
+  isWordComposing() {
+    return this.getWord() && this.getPhoneme() !== this.getLastCharacter();
+  }
+
   isComposing() {
-    return this.getPhoneme() !== '' && this.getWord() === '';
+    return this.isCharacterComposing() || this.isWordComposing();
   }
 }

--- a/views/javascript/constants/endingMap.js
+++ b/views/javascript/constants/endingMap.js
@@ -14,6 +14,8 @@ export const formalEndingMap = {
   배웠: '습니다.',
 
   었: '습니다.',
+  습: '니다.',
+  입: '니다.',
 };
 
 export const politeEndingMap = {


### PR DESCRIPTION
🚀 resolved #130
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

자동 완성이 되는 경우의 수가 많은데, 이에 대해 서로 다른 삭제/삽입 처리를 해주지 않아 발생한 버그

경우의 수
1. 조합중인 첫문자부터 자동 완성할 수 있는 경우 (ex. `했`)
2. 조합중이지 않은 문자/단어로 자동 완성할 수 있는 경우 (ex. `했|`, `되었|`)
3. 조합중인 마지막 문자를 제외하고 자동 완성할 수 있는 경우 (ex. `했ㅅ`, `느꼈ㅅ`)
4. 조합중이면서 마지막 문자에서 자동 완성할 수 있는 경우 (ex. `말했`, `공부했`

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

자동 완성을 실행하는 `execute` 함수에서 각 경우의 수 별로 삽입/삭제 시점을 다르게 설정

```ts
// 삭제 처리 
if (!this.#inputTracker.isComposing()) { // 2번 경우의 수
  removeIncompleteCallback(
    this.#computeRemovePointerForCompositionEnd(ending),
  );
} else if (this.#isEndingWithoutComposingCharacter(ending)) { // 3번 경우의 수
  removeIncompleteCallback(
    this.#computeRemovePointerForCompositionUpdate(),
  );
} else if (this.#isEndingWithLastCharacter(ending)) { // 4번 경우의 수
  removeIncompleteCallback(
    this.#computeRemovePointerForCompositionUpdate(),
  );
}
// 삽입 시점 다르게 처리
const insertPointer = this.#computeInsertPointer(ending);
```

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
