### PR TITLE
Fix(#136): 줄바꿈 나눈 결과 예외처리

### DIFF
--- a/views/javascript/longSentence/longSentence.js
+++ b/views/javascript/longSentence/longSentence.js
@@ -55,7 +55,11 @@ export class LongSentence {
     );
 
     const trimedSentence = sentence.replace(/^\s+|\s+$/g, '');
-    const parsedSentence = await response.text();
+    const parsedSentence = (await response.text()).replace(
+      /(\s|\r?\n){2,}/g,
+      ' ',
+    );
+
     return sentence.replace(
       new RegExp(`(\\s*)${trimedSentence}(\\s*)`),
       `$1${parsedSentence}$2`,


### PR DESCRIPTION
🚀 resolved #136
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

close #136 

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

![image](https://github.com/user-attachments/assets/c59a1d87-41f8-449d-8db4-ecc36d46679b)

</br>

클로바 응답을 받아와서 팝업에 보여줄 때는 줄바꿈 없이 잘 보여지는데 반영하면 줄바꿈이나 공백들이 생기는 문제가 발생했습니다.
뭐가 문제일까 싶어서 봤는데 애초에 클로바 API 호출 응답부터가 공백이나 줄바꿈이 나뉜 문장에 섞여서 오는 경우가 있어서 이 경우를 예외처리 해줬습니다. ~~(왜 팝업에서 반영결과를 미리 보여줄 때는 잘 보이는지 모르겠지만...)~~

</br>

정규식으로 반영하기 전에 줄바꿈이나 공백을 제거해줬습니다.