### PR TITLE
Refactor(#145): 콘솔 출력문 대신 로거를 사용한다

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,13 @@ services:
     ports:
       - ${HOST_PORT}:${CONTAINER_PORT}
     env_file: .env
+    volumes:
+      - /logs:/logs
 
   redis:
     container_name: redis
     image: redis:latest
     expose:
       - ${REDIS_PORT}
+    volumes:
+      - /data:/data

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "hanspell": "^0.9.7",
     "hbs": "^4.2.0",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "winston": "^3.14.2",
+    "winston-daily-rotate-file": "^5.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,14 +1,11 @@
 import * as dotenv from 'dotenv';
 import { Controller, Get, Render } from '@nestjs/common';
-import { AppService } from './app.service';
 import { FEEDBACK_CRITERIA, MODIFICATION_OPTIONS } from './clova/constants';
 
 dotenv.config();
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
-
   @Get()
   @Render('index')
   root(): any {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { ClovaModule } from './clova/clova.module';
 import { RedisModule } from './common/cache/redis/redis.module';
+import { ExceptionInterceptor } from './common/exception/exception.interceptor';
 import { LoggerModule } from './common/log/logger.module';
 import { SpellModule } from './spell/spell.module';
 
@@ -15,5 +17,11 @@ import { SpellModule } from './spell/spell.module';
     LoggerModule,
   ],
   controllers: [AppController],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ExceptionInterceptor,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
-import { AppService } from './app.service';
 import { ClovaModule } from './clova/clova.module';
 import { RedisModule } from './common/cache/redis/redis.module';
+import { LoggerModule } from './common/log/logger.module';
 import { SpellModule } from './spell/spell.module';
 
 @Module({
@@ -12,8 +12,8 @@ import { SpellModule } from './spell/spell.module';
     SpellModule,
     ClovaModule,
     RedisModule.register(),
+    LoggerModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
 })
 export class AppModule {}

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,4 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class AppService {}

--- a/src/clova/clova.module.ts
+++ b/src/clova/clova.module.ts
@@ -1,3 +1,4 @@
+import { LoggerModule } from 'src/common/log/logger.module';
 import { Module } from '@nestjs/common';
 import { ClovaController } from './clova.controller';
 import { FeedbackService } from './services/feedback.service';
@@ -11,6 +12,7 @@ import {
 } from './utils';
 
 @Module({
+  imports: [LoggerModule],
   controllers: [ClovaController],
   providers: [
     PartialModificationService,

--- a/src/clova/services/feedback.service.ts
+++ b/src/clova/services/feedback.service.ts
@@ -1,3 +1,4 @@
+import { axiosPost } from 'src/common/utils';
 import { Injectable } from '@nestjs/common';
 import { ClovaChatCompletionsRequestHeadersForHCX003 } from '../constants';
 import {
@@ -9,7 +10,6 @@ import {
 import {
   ClovaRequestBodyTransformer,
   ClovaResponseBodyTransformer,
-  axiosPost,
 } from '../utils';
 
 @Injectable()

--- a/src/clova/services/parsed-sentence.service.ts
+++ b/src/clova/services/parsed-sentence.service.ts
@@ -1,3 +1,4 @@
+import { axiosPost } from 'src/common/utils';
 import { Injectable } from '@nestjs/common';
 import { ClovaChatCompletionsRequestHeaders } from '../constants';
 import {
@@ -7,7 +8,7 @@ import {
   ClovaRequestHeader,
   ClovaResponse,
 } from '../types';
-import { ClovaRequestBodyTransformer, axiosPost } from '../utils';
+import { ClovaRequestBodyTransformer } from '../utils';
 
 @Injectable()
 export class ParsedSentenceService {

--- a/src/clova/services/partial-modification.service.ts
+++ b/src/clova/services/partial-modification.service.ts
@@ -1,4 +1,5 @@
 import { RedisManager } from 'src/common/cache/redis/redis.manager';
+import { axiosPost, fetchPost } from 'src/common/utils';
 import { Injectable } from '@nestjs/common';
 import {
   ClovaChatCompletionsRequestHeadersForHCX003,
@@ -16,8 +17,6 @@ import {
 import {
   ClovaRequestBodyTransformer,
   ClovaResponseBodyTransformer,
-  axiosPost,
-  fetchPost,
 } from '../utils';
 
 @Injectable()

--- a/src/clova/services/repetitive-word.service.ts
+++ b/src/clova/services/repetitive-word.service.ts
@@ -1,3 +1,4 @@
+import { axiosPost } from 'src/common/utils';
 import { Injectable } from '@nestjs/common';
 import { ClovaChatCompletionsRequestHeaders } from '../constants';
 import {
@@ -6,7 +7,7 @@ import {
   ClovaRequestHeader,
   ClovaResponse,
 } from '../types';
-import { ClovaRequestBodyTransformer, axiosPost } from '../utils';
+import { ClovaRequestBodyTransformer } from '../utils';
 
 @Injectable()
 export class RepetitiveWordService {

--- a/src/clova/utils/index.ts
+++ b/src/clova/utils/index.ts
@@ -1,5 +1,4 @@
 export * from './clova-event.parser';
-export * from './request-api';
 export * from './request-body.transformer';
 export * from './response-body.parser';
 export * from './response-body.transformer';

--- a/src/clova/utils/request-api.ts
+++ b/src/clova/utils/request-api.ts
@@ -7,9 +7,8 @@ export async function axiosPost(
 ): Promise<any> {
   try {
     return await axios.post(url, data, { headers: headers });
-  } catch (err) {
-    console.error(err);
-    throw new Error(`[axios] Failed to request '${url}'`);
+  } catch (err: unknown) {
+    throw new Error(`[axios] 요청 실패 '${url}'`);
   }
 }
 
@@ -24,8 +23,7 @@ export async function fetchPost(
       headers: headers,
       body: JSON.stringify(data),
     });
-  } catch (err) {
-    console.error(err);
-    throw new Error(`[fetch] Failed to request '${url}'`);
+  } catch (err: unknown) {
+    throw new Error(`[fetch] 요청 실패 '${url}'`);
   }
 }

--- a/src/common/exception/exception.interceptor.ts
+++ b/src/common/exception/exception.interceptor.ts
@@ -1,0 +1,28 @@
+import { Observable, catchError, throwError } from 'rxjs';
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { WinstonService } from '../log/winston/winston.service';
+
+@Injectable()
+export class ExceptionInterceptor implements NestInterceptor {
+  constructor(private readonly logger: WinstonService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const controllerName: string = context.getClass().name;
+
+    return next.handle().pipe(
+      catchError((err: unknown) => {
+        this.logger.error(this.makeLogMessage(err), controllerName);
+        return throwError(() => err);
+      }),
+    );
+  }
+
+  private makeLogMessage(err: unknown): string {
+    return err instanceof Error ? err.message : JSON.stringify(err);
+  }
+}

--- a/src/common/log/logger.module.ts
+++ b/src/common/log/logger.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { WinstonService } from './winston/winston.service';
+
+@Module({
+  providers: [WinstonService],
+  exports: [WinstonService],
+})
+export class LoggerModule {}

--- a/src/common/log/winston/winston.format.ts
+++ b/src/common/log/winston/winston.format.ts
@@ -2,7 +2,7 @@ import { format } from 'winston';
 
 const printfFormat = () =>
   format.printf(({ level, message, timestamp, stack }) => {
-    const logMessage: string = `[${level}]\t${timestamp}\t${message}`;
+    const logMessage: string = `[API Server] - ${timestamp}\t${level} ${message}`;
     return stack ? `${logMessage}\n${stack}` : logMessage;
   });
 

--- a/src/common/log/winston/winston.format.ts
+++ b/src/common/log/winston/winston.format.ts
@@ -1,0 +1,16 @@
+import { format } from 'winston';
+
+const printfFormat = () =>
+  format.printf(({ level, message, timestamp, stack }) => {
+    const logMessage: string = `[${level}]\t${timestamp}\t${message}`;
+    return stack ? `${logMessage}\n${stack}` : logMessage;
+  });
+
+export const customFormat = () =>
+  format.combine(
+    format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+    format.errors({ stack: true }),
+    format.splat(),
+    format.colorize(),
+    printfFormat(),
+  );

--- a/src/common/log/winston/winston.logger.ts
+++ b/src/common/log/winston/winston.logger.ts
@@ -1,0 +1,19 @@
+import { Logger, createLogger } from 'winston';
+import { customFormat } from './winston.format';
+import {
+  debugTransports,
+  errorTransports,
+  infoTransports,
+  warnTransports,
+} from './winston.transport';
+
+export const winstonLogger = (): Logger =>
+  createLogger({
+    format: customFormat(),
+    transports: [
+      debugTransports,
+      infoTransports,
+      warnTransports,
+      errorTransports,
+    ],
+  });

--- a/src/common/log/winston/winston.service.ts
+++ b/src/common/log/winston/winston.service.ts
@@ -2,23 +2,25 @@ import { Logger } from 'winston';
 import { Injectable } from '@nestjs/common';
 import { winstonLogger } from './winston.logger';
 
+const UNKNOWN: string = 'Unknown';
+
 @Injectable()
 export class WinstonService {
   private readonly logger: Logger = winstonLogger();
 
-  debug(message: string, context: string = 'Unknown', ...args: any): void {
+  debug(message: string, context: string = UNKNOWN, ...args: any): void {
     this.logger.debug(this.makeLogMessage(message, context), ...args);
   }
 
-  info(message: string, context: string = 'Unknown', ...args: any): void {
+  info(message: string, context: string = UNKNOWN, ...args: any): void {
     this.logger.info(this.makeLogMessage(message, context), ...args);
   }
 
-  warn(message: string, context: string = 'Unknown', ...args: any): void {
+  warn(message: string, context: string = UNKNOWN, ...args: any): void {
     this.logger.warn(this.makeLogMessage(message, context), ...args);
   }
 
-  error(message: string, context: string = 'Unknown', ...args: any): void {
+  error(message: string, context: string = UNKNOWN, ...args: any): void {
     this.logger.error(this.makeLogMessage(message, context), ...args);
   }
 

--- a/src/common/log/winston/winston.service.ts
+++ b/src/common/log/winston/winston.service.ts
@@ -1,0 +1,31 @@
+import { Logger } from 'winston';
+import { Injectable } from '@nestjs/common';
+import { winstonLogger } from './winston.logger';
+
+const COMMON_PREFIX: string = 'LOG ';
+
+@Injectable()
+export class WinstonService {
+  private readonly logger: Logger = winstonLogger();
+
+  debug(message: string, prefix: string = 'Unknown', ...args: any): void {
+    this.logger.debug(this.makeLogMessage(message, prefix), ...args);
+  }
+
+  info(message: string, prefix: string = 'Unknown', ...args: any): void {
+    this.logger.info(this.makeLogMessage(message, prefix), ...args);
+  }
+
+  warn(message: string, prefix: string = 'Unknown', ...args: any): void {
+    this.logger.warn(this.makeLogMessage(message, prefix), ...args);
+  }
+
+  error(message: string, prefix: string = 'Unknown', trace?: string): void {
+    const logMessage: string = this.makeLogMessage(message, prefix);
+    this.logger.error(trace ? `${logMessage}\n${trace}` : logMessage);
+  }
+
+  private makeLogMessage(message: string, prefix: string): string {
+    return `${COMMON_PREFIX}[${prefix}] ${message}`;
+  }
+}

--- a/src/common/log/winston/winston.service.ts
+++ b/src/common/log/winston/winston.service.ts
@@ -2,30 +2,27 @@ import { Logger } from 'winston';
 import { Injectable } from '@nestjs/common';
 import { winstonLogger } from './winston.logger';
 
-const COMMON_PREFIX: string = 'LOG ';
-
 @Injectable()
 export class WinstonService {
   private readonly logger: Logger = winstonLogger();
 
-  debug(message: string, prefix: string = 'Unknown', ...args: any): void {
-    this.logger.debug(this.makeLogMessage(message, prefix), ...args);
+  debug(message: string, context: string = 'Unknown', ...args: any): void {
+    this.logger.debug(this.makeLogMessage(message, context), ...args);
   }
 
-  info(message: string, prefix: string = 'Unknown', ...args: any): void {
-    this.logger.info(this.makeLogMessage(message, prefix), ...args);
+  info(message: string, context: string = 'Unknown', ...args: any): void {
+    this.logger.info(this.makeLogMessage(message, context), ...args);
   }
 
-  warn(message: string, prefix: string = 'Unknown', ...args: any): void {
-    this.logger.warn(this.makeLogMessage(message, prefix), ...args);
+  warn(message: string, context: string = 'Unknown', ...args: any): void {
+    this.logger.warn(this.makeLogMessage(message, context), ...args);
   }
 
-  error(message: string, prefix: string = 'Unknown', trace?: string): void {
-    const logMessage: string = this.makeLogMessage(message, prefix);
-    this.logger.error(trace ? `${logMessage}\n${trace}` : logMessage);
+  error(message: string, context: string = 'Unknown', ...args: any): void {
+    this.logger.error(this.makeLogMessage(message, context), ...args);
   }
 
-  private makeLogMessage(message: string, prefix: string): string {
-    return `${COMMON_PREFIX}[${prefix}] ${message}`;
+  private makeLogMessage(message: string, context: string): string {
+    return `[${context}] ${message}`;
   }
 }

--- a/src/common/log/winston/winston.transport.ts
+++ b/src/common/log/winston/winston.transport.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs';
+import { transports } from 'winston';
+import * as DailyRotateFile from 'winston-daily-rotate-file';
+
+const dirname: string = 'logs';
+
+function createDailyRotateFile(level: string): DailyRotateFile {
+  if (!fs.existsSync(dirname)) {
+    fs.mkdirSync(dirname);
+  }
+
+  return new DailyRotateFile({
+    level,
+    dirname,
+    filename: `${level}-%DATE%.log`,
+    datePattern: 'YYYY-MM-DD',
+    zippedArchive: true,
+    maxSize: '20m',
+    maxFiles: '7d',
+  });
+}
+
+export const debugTransports = new transports.Console({
+  level: 'debug',
+});
+export const infoTransports: DailyRotateFile = createDailyRotateFile('info');
+export const warnTransports: DailyRotateFile = createDailyRotateFile('warn');
+export const errorTransports: DailyRotateFile = createDailyRotateFile('error');

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './request-api';

--- a/src/common/utils/request-api.ts
+++ b/src/common/utils/request-api.ts
@@ -8,7 +8,7 @@ export async function axiosPost(
   try {
     return await axios.post(url, data, { headers: headers });
   } catch (err: unknown) {
-    throw new Error(`[axios] 요청 실패 '${url}'`);
+    throw new Error(`axios 요청에 실패했습니다. '${url}'`);
   }
 }
 
@@ -24,6 +24,6 @@ export async function fetchPost(
       body: JSON.stringify(data),
     });
   } catch (err: unknown) {
-    throw new Error(`[fetch] 요청 실패 '${url}'`);
+    throw new Error(`fetch 요청에 실패했습니다. '${url}'`);
   }
 }

--- a/src/spell/spell.module.ts
+++ b/src/spell/spell.module.ts
@@ -1,8 +1,10 @@
+import { LoggerModule } from 'src/common/log/logger.module';
 import { Module } from '@nestjs/common';
 import { SpellController } from './spell.controller';
 import { SpellService } from './spell.service';
 
 @Module({
+  imports: [LoggerModule],
   controllers: [SpellController],
   providers: [SpellService],
 })


### PR DESCRIPTION
🚀 resolved #145
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- 로거 관련 설정 작성
- 예외 인터셉터 작성

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 콘솔 출력문 대신 winston 로거를 사용하도록 리팩토링
- 로그 레벨 세분화 (debug - info - warn - error)
- 글로벌한 예외 인터셉터를 활용하여 예외가 발생하면 무조건 로그를 출력하도록 설정

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
`-- 한스펠 오류: 다음 서버의 접속 오류로 일부 문장 교정에 실패했습니다.` 는 어디에서 출력하는 건가요? 어디에도 출력문이 없는 것 같아 


## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
![image](https://github.com/user-attachments/assets/4407d681-9bc1-4319-91bd-cc097c9e6869)